### PR TITLE
Ported Octree class and supporting classes from the server to the client

### DIFF
--- a/Assets/Cube Loader/src/Contracts.meta
+++ b/Assets/Cube Loader/src/Contracts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2b43cfcff7508e7418549c349e321c76
+folderAsset: yes
+timeCreated: 1429899091
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Contracts/IBounds.cs
+++ b/Assets/Cube Loader/src/Contracts/IBounds.cs
@@ -1,0 +1,30 @@
+﻿// // //------------------------------------------------------------------------------------------------- 
+// // // <copyright file="IBounds.cs" company="Microsoft Corporation">
+// // // Copyright (c) Microsoft Corporation. All rights reserved.
+// // // </copyright>
+// // //-------------------------------------------------------------------------------------------------
+
+namespace Pyrite.Client.Contracts
+{
+    using Pyrite.Client.Model;
+    using Microsoft.Xna;
+    using UnityEngine;
+    using Microsoft.Xna.Framework;
+
+    public interface IBounds<TObject>
+    {
+        BoundingBox BoundingBox { get; }
+
+        BoundingSphere BoundingSphere { get; }
+
+        Intersection<TObject> Intersects(Ray ray);
+
+        Intersection<TObject> Intersects(TObject obj);
+
+        Intersection<TObject> Intersects(BoundingBox intersectionBox);
+
+        Intersection<TObject> Intersects(BoundingFrustum frustum);
+
+        Intersection<TObject> Intersects(BoundingSphere intersectionSphere);
+    }
+}

--- a/Assets/Cube Loader/src/Contracts/IBounds.cs.meta
+++ b/Assets/Cube Loader/src/Contracts/IBounds.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2d60f21613b3e544caa35eae5cc006ea
+timeCreated: 1429899091
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: db617205c3776cc4ea98ba8f34055934
+folderAsset: yes
+timeCreated: 1429899091
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingBox.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingBox.cs
@@ -1,0 +1,430 @@
+﻿#region License
+/*
+MIT License
+Copyright © 2006 The Mono.Xna Team
+
+All rights reserved.
+
+Authors:
+Olivier Dufour (Duff)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion License
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    public struct BoundingBox : IEquatable<BoundingBox>
+    {
+
+        #region Public Fields
+
+        public Vector3 Min;
+        public Vector3 Max;
+        public const int CornerCount = 8;
+
+        #endregion Public Fields
+
+
+        #region Public Constructors
+
+        public BoundingBox(Vector3 min, Vector3 max)
+        {
+            this.Min = min;
+            this.Max = max;
+        }
+
+        #endregion Public Constructors
+
+
+        #region Public Methods
+
+        public ContainmentType Contains(BoundingBox box)
+        {
+            //test if all corner is in the same side of a face by just checking min and max
+            if (box.Max.x < Min.x
+                || box.Min.x > Max.x
+                || box.Max.y < Min.y
+                || box.Min.y > Max.y
+                || box.Max.z < Min.z
+                || box.Min.z > Max.z)
+                return ContainmentType.Disjoint;
+
+
+            if (box.Min.x >= Min.x
+                && box.Max.x <= Max.x
+                && box.Min.y >= Min.y
+                && box.Max.y <= Max.y
+                && box.Min.z >= Min.z
+                && box.Max.z <= Max.z)
+                return ContainmentType.Contains;
+
+            return ContainmentType.Intersects;
+        }
+
+        public void Contains(ref BoundingBox box, out ContainmentType result)
+        {
+            result = Contains(box);
+        }
+
+        public ContainmentType Contains(BoundingFrustum frustum)
+        {
+            //TODO: bad done here need a fix. 
+            //Because question is not frustum contain box but reverse and this is not the same
+            int i;
+            ContainmentType contained;
+            Vector3[] corners = frustum.GetCorners();
+
+            // First we check if frustum is in box
+            for (i = 0; i < corners.Length; i++)
+            {
+                this.Contains(ref corners[i], out contained);
+                if (contained == ContainmentType.Disjoint)
+                    break;
+            }
+
+            if (i == corners.Length) // This means we checked all the corners and they were all contain or instersect
+                return ContainmentType.Contains;
+
+            if (i != 0)             // if i is not equal to zero, we can fastpath and say that this box intersects
+                return ContainmentType.Intersects;
+
+
+            // If we get here, it means the first (and only) point we checked was actually contained in the frustum.
+            // So we assume that all other points will also be contained. If one of the points is disjoint, we can
+            // exit immediately saying that the result is Intersects
+            i++;
+            for (; i < corners.Length; i++)
+            {
+                this.Contains(ref corners[i], out contained);
+                if (contained != ContainmentType.Contains)
+                    return ContainmentType.Intersects;
+
+            }
+
+            // If we get here, then we know all the points were actually contained, therefore result is Contains
+            return ContainmentType.Contains;
+        }
+
+        public ContainmentType Contains(BoundingSphere sphere)
+        {
+            if (sphere.Center.x - Min.x > sphere.Radius
+                && sphere.Center.y - Min.y > sphere.Radius
+                && sphere.Center.z - Min.z > sphere.Radius
+                && Max.x - sphere.Center.x > sphere.Radius
+                && Max.y - sphere.Center.y > sphere.Radius
+                && Max.z - sphere.Center.z > sphere.Radius)
+                return ContainmentType.Contains;
+
+            double dmin = 0;
+
+            // Fixed bug in logic for sphere intersection
+
+            if (sphere.Center.x < Min.x)
+                dmin += (sphere.Center.x - Min.x) * (sphere.Center.x - Min.x);
+            else if (Max.x < sphere.Center.x)
+                dmin += (sphere.Center.x - Max.x) * (sphere.Center.x - Max.x);
+
+            if (sphere.Center.y < Min.y)
+                dmin += (sphere.Center.y - Min.y) * (sphere.Center.y - Min.y);
+            else if (Max.y < sphere.Center.y )
+                dmin += (sphere.Center.y - Max.y) * (sphere.Center.y - Max.y);
+
+            if (sphere.Center.z < Min.z)
+                dmin += (sphere.Center.z - Min.z) * (sphere.Center.z - Min.z);
+            else if (Max.z < sphere.Center.z)
+                dmin += (sphere.Center.z - Max.z) * (sphere.Center.z - Max.z);
+
+            if (dmin <= sphere.Radius * sphere.Radius)
+                return ContainmentType.Intersects;
+
+            return ContainmentType.Disjoint;
+        }
+
+        public void Contains(ref BoundingSphere sphere, out ContainmentType result)
+        {
+            result = this.Contains(sphere);
+        }
+
+        public ContainmentType Contains(Vector3 point)
+        {
+            ContainmentType result;
+            this.Contains(ref point, out result);
+            return result;
+        }
+
+        public void Contains(ref Vector3 point, out ContainmentType result)
+        {
+            //first we get if point is out of box
+            if (point.x < this.Min.x
+                || point.x > this.Max.x
+                || point.y < this.Min.y
+                || point.y > this.Max.y
+                || point.z < this.Min.z
+                || point.z > this.Max.z)
+            {
+                result = ContainmentType.Disjoint;
+            }//or if point is on box because coordonate of point is lesser or equal
+            else if (point.x == this.Min.x
+                || point.x == this.Max.x
+                || point.y == this.Min.y
+                || point.y == this.Max.y
+                || point.z == this.Min.z
+                || point.z == this.Max.z)
+                result = ContainmentType.Intersects;
+            else
+                result = ContainmentType.Contains;
+
+
+        }
+
+        public static BoundingBox CreateFromPoints(IEnumerable<Vector3> points)
+        {
+            if (points == null)
+                throw new ArgumentNullException();
+
+            // TODO: Just check that Count > 0
+            bool empty = true;
+            Vector3 vector2 = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            Vector3 vector1 = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+            foreach (Vector3 vector3 in points)
+            {
+                vector2 = Vector3.Min(vector2, vector3);
+                vector1 = Vector3.Max(vector1, vector3);
+                empty = false;
+            }
+            if (empty)
+                throw new ArgumentException();
+
+            return new BoundingBox(vector2, vector1);
+        }
+
+        public static BoundingBox CreateFromSphere(BoundingSphere sphere)
+        {
+            Vector3 vector1 = new Vector3(sphere.Radius, sphere.Radius, sphere.Radius);
+            return new BoundingBox(sphere.Center - vector1, sphere.Center + vector1);
+        }
+
+        public static void CreateFromSphere(ref BoundingSphere sphere, out BoundingBox result)
+        {
+            result = BoundingBox.CreateFromSphere(sphere);
+        }
+
+        public static BoundingBox CreateMerged(BoundingBox original, BoundingBox additional)
+        {
+            return new BoundingBox(
+                Vector3.Min(original.Min, additional.Min), Vector3.Max(original.Max, additional.Max));
+        }
+
+        public static void CreateMerged(ref BoundingBox original, ref BoundingBox additional, out BoundingBox result)
+        {
+            result = BoundingBox.CreateMerged(original, additional);
+        }
+
+        public bool Equals(BoundingBox other)
+        {
+            return (this.Min == other.Min) && (this.Max == other.Max);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj is BoundingBox) ? this.Equals((BoundingBox)obj) : false;
+        }
+
+        public Vector3[] GetCorners()
+        {
+            return new Vector3[] {
+                new Vector3(this.Min.x, this.Max.y, this.Max.z), 
+                new Vector3(this.Max.x, this.Max.y, this.Max.z),
+                new Vector3(this.Max.x, this.Min.y, this.Max.z), 
+                new Vector3(this.Min.x, this.Min.y, this.Max.z), 
+                new Vector3(this.Min.x, this.Max.y, this.Min.z),
+                new Vector3(this.Max.x, this.Max.y, this.Min.z),
+                new Vector3(this.Max.x, this.Min.y, this.Min.z),
+                new Vector3(this.Min.x, this.Min.y, this.Min.z)
+            };
+        }
+
+        public void GetCorners(Vector3[] corners)
+        {
+            if (corners == null)
+            {
+                throw new ArgumentNullException("corners");
+            }
+            if (corners.Length < 8)
+            {
+                throw new ArgumentOutOfRangeException("corners", "Not Enought Corners");
+            }
+            corners[0].x = this.Min.x;
+            corners[0].y = this.Max.y;
+            corners[0].z = this.Max.z;
+            corners[1].x = this.Max.x;
+            corners[1].y = this.Max.y;
+            corners[1].z = this.Max.z;
+            corners[2].x = this.Max.x;
+            corners[2].y = this.Min.y;
+            corners[2].z = this.Max.z;
+            corners[3].x = this.Min.x;
+            corners[3].y = this.Min.y;
+            corners[3].z = this.Max.z;
+            corners[4].x = this.Min.x;
+            corners[4].y = this.Max.y;
+            corners[4].z = this.Min.z;
+            corners[5].x = this.Max.x;
+            corners[5].y = this.Max.y;
+            corners[5].z = this.Min.z;
+            corners[6].x = this.Max.x;
+            corners[6].y = this.Min.y;
+            corners[6].z = this.Min.z;
+            corners[7].x = this.Min.x;
+            corners[7].y = this.Min.y;
+            corners[7].z = this.Min.z;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Min.GetHashCode() + this.Max.GetHashCode();
+        }
+
+        public bool Intersects(BoundingBox box)
+        {
+            bool result;
+            Intersects(ref box, out result);
+            return result;
+        }
+
+        public void Intersects(ref BoundingBox box, out bool result)
+        {
+            if ((this.Max.x >= box.Min.x) && (this.Min.x <= box.Max.x))
+            {
+                if ((this.Max.y < box.Min.y) || (this.Min.y > box.Max.y))
+                {
+                    result = false;
+                    return;
+                }
+
+                result = (this.Max.z >= box.Min.z) && (this.Min.z <= box.Max.z);
+                return;
+            }
+
+            result = false;
+            return;
+        }
+
+        public bool Intersects(BoundingFrustum frustum)
+        {
+            return frustum.Intersects(this);
+        }
+
+        public bool Intersects(BoundingSphere sphere)
+        {
+            if (sphere.Center.x - Min.x > sphere.Radius
+                && sphere.Center.y - Min.y > sphere.Radius
+                && sphere.Center.z - Min.z > sphere.Radius
+                && Max.x - sphere.Center.x > sphere.Radius
+                && Max.y - sphere.Center.y > sphere.Radius
+                && Max.z - sphere.Center.z > sphere.Radius)
+                return true;
+
+            double dmin = 0;
+
+            if (sphere.Center.x - Min.x <= sphere.Radius)
+                dmin += (sphere.Center.x - Min.x) * (sphere.Center.x - Min.x);
+            else if (Max.x - sphere.Center.x <= sphere.Radius)
+                dmin += (sphere.Center.x - Max.x) * (sphere.Center.x - Max.x);
+
+            if (sphere.Center.y - Min.y <= sphere.Radius)
+                dmin += (sphere.Center.y - Min.y) * (sphere.Center.y - Min.y);
+            else if (Max.y - sphere.Center.y <= sphere.Radius)
+                dmin += (sphere.Center.y - Max.y) * (sphere.Center.y - Max.y);
+
+            if (sphere.Center.z - Min.z <= sphere.Radius)
+                dmin += (sphere.Center.z - Min.z) * (sphere.Center.z - Min.z);
+            else if (Max.z - sphere.Center.z <= sphere.Radius)
+                dmin += (sphere.Center.z - Max.z) * (sphere.Center.z - Max.z);
+
+            if (dmin <= sphere.Radius * sphere.Radius)
+                return true;
+
+            return false;
+        }
+
+        public void Intersects(ref BoundingSphere sphere, out bool result)
+        {
+            result = Intersects(sphere);
+        }
+
+        public PlaneIntersectionType Intersects(Plane plane)
+        {
+            //check all corner side of plane
+            Vector3[] corners = this.GetCorners();
+            float lastdistance = Vector3.Dot(plane.normal, corners[0]) + plane.distance;
+
+            for (int i = 1; i < corners.Length; i++)
+            {
+                float distance = Vector3.Dot(plane.normal, corners[i]) + plane.distance;
+                if ((distance <= 0.0f && lastdistance > 0.0f) || (distance >= 0.0f && lastdistance < 0.0f))
+                    return PlaneIntersectionType.Intersecting;
+                lastdistance = distance;
+            }
+
+            if (lastdistance > 0.0f)
+                return PlaneIntersectionType.Front;
+
+            return PlaneIntersectionType.Back;
+
+        }
+
+        public void Intersects(ref Plane plane, out PlaneIntersectionType result)
+        {
+            result = Intersects(plane);
+        }
+
+        public Nullable<float> Intersects(Ray ray)
+        {
+            return ray.Intersects(this);
+        }
+
+        public void Intersects(ref Ray ray, out Nullable<float> result)
+        {
+            result = Intersects(ray);
+        }
+
+        public static bool operator ==(BoundingBox a, BoundingBox b)
+        {
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(BoundingBox a, BoundingBox b)
+        {
+            return !a.Equals(b);
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{{Min:{0} Max:{1}}}", this.Min.ToString(), this.Max.ToString());
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingBox.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingBox.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9eed6b70776d55a4babd0f62c7802bb0
+timeCreated: 1429899093
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs
@@ -454,31 +454,61 @@ namespace Microsoft.Xna.Framework
 
         private void CreatePlanes()
         {
+            this.left = new Plane() { normal = new Vector3(-this.matrix.M14 - this.matrix.M11, 
+                -this.matrix.M24 - this.matrix.M21, 
+                -this.matrix.M34 - this.matrix.M31), 
+                distance = -this.matrix.M44 - this.matrix.M41 };
+
+            this.right = new Plane() { normal = new Vector3(this.matrix.M11 - this.matrix.M14, 
+                this.matrix.M21 - this.matrix.M24, 
+                this.matrix.M31 - this.matrix.M34), 
+                distance = this.matrix.M41 - this.matrix.M44 };
+
+            this.top = new Plane() { normal = new Vector3(this.matrix.M12 - this.matrix.M14, 
+                this.matrix.M22 - this.matrix.M24,
+                this.matrix.M32 - this.matrix.M34), 
+                distance = this.matrix.M42 - this.matrix.M44 };
+
+            this.bottom = new Plane() { normal = new Vector3(-this.matrix.M14 - this.matrix.M12, 
+                -this.matrix.M24 - this.matrix.M22, 
+                -this.matrix.M34 - this.matrix.M32), 
+                distance = -this.matrix.M44 - this.matrix.M42 };
+
+            this.near = new Plane() { normal = new Vector3(-this.matrix.M13, 
+                -this.matrix.M23, 
+                -this.matrix.M33), 
+                distance = -this.matrix.M43 };
+
+            this.far = new Plane() { normal = new Vector3(this.matrix.M13 - this.matrix.M14, 
+                this.matrix.M23 - this.matrix.M24, 
+                this.matrix.M33 - this.matrix.M34), 
+                distance = this.matrix.M43 - this.matrix.M44 };
+
             // Pre-calculate the different planes needed
-            this.left = new Plane(-this.matrix.M14 - this.matrix.M11, -this.matrix.M24 - this.matrix.M21,
-                                  -this.matrix.M34 - this.matrix.M31, -this.matrix.M44 - this.matrix.M41);
+            //this.left = new Plane(-this.matrix.M14 - this.matrix.M11, -this.matrix.M24 - this.matrix.M21,
+            //                      -this.matrix.M34 - this.matrix.M31, -this.matrix.M44 - this.matrix.M41);
 
-            this.right = new Plane(this.matrix.M11 - this.matrix.M14, this.matrix.M21 - this.matrix.M24,
-                                   this.matrix.M31 - this.matrix.M34, this.matrix.M41 - this.matrix.M44);
+            //this.right = new Plane(this.matrix.M11 - this.matrix.M14, this.matrix.M21 - this.matrix.M24,
+            //                       this.matrix.M31 - this.matrix.M34, this.matrix.M41 - this.matrix.M44);
 
-            this.top = new Plane(this.matrix.M12 - this.matrix.M14, this.matrix.M22 - this.matrix.M24,
-                                 this.matrix.M32 - this.matrix.M34, this.matrix.M42 - this.matrix.M44);
+            //this.top = new Plane(this.matrix.M12 - this.matrix.M14, this.matrix.M22 - this.matrix.M24,
+            //                     this.matrix.M32 - this.matrix.M34, this.matrix.M42 - this.matrix.M44);
 
-            this.bottom = new Plane(-this.matrix.M14 - this.matrix.M12, -this.matrix.M24 - this.matrix.M22,
-                                    -this.matrix.M34 - this.matrix.M32, -this.matrix.M44 - this.matrix.M42);
+            //this.bottom = new Plane(-this.matrix.M14 - this.matrix.M12, -this.matrix.M24 - this.matrix.M22,
+            //                        -this.matrix.M34 - this.matrix.M32, -this.matrix.M44 - this.matrix.M42);
 
-            this.near = new Plane(-this.matrix.M13, -this.matrix.M23, -this.matrix.M33, -this.matrix.M43);
+            //this.near = new Plane(-this.matrix.M13, -this.matrix.M23, -this.matrix.M33, -this.matrix.M43);
 
 
-            this.far = new Plane(this.matrix.M13 - this.matrix.M14, this.matrix.M23 - this.matrix.M24,
-                                 this.matrix.M33 - this.matrix.M34, this.matrix.M43 - this.matrix.M44);
+            //this.far = new Plane(this.matrix.M13 - this.matrix.M14, this.matrix.M23 - this.matrix.M24,
+            //                     this.matrix.M33 - this.matrix.M34, this.matrix.M43 - this.matrix.M44);
 
-            this.NormalizePlane(ref this.left);
-            this.NormalizePlane(ref this.right);
-            this.NormalizePlane(ref this.top);
-            this.NormalizePlane(ref this.bottom);
-            this.NormalizePlane(ref this.near);
-            this.NormalizePlane(ref this.far);
+            this.normalizePlane(ref this.left);
+            this.normalizePlane(ref this.right);
+            this.normalizePlane(ref this.top);
+            this.normalizePlane(ref this.bottom);
+            this.normalizePlane(ref this.near);
+            this.normalizePlane(ref this.far);
         }
 
         private static Vector3 IntersectionPoint(ref Plane a, ref Plane b, ref Plane c)
@@ -491,23 +521,26 @@ namespace Microsoft.Xna.Framework
             // Note: N refers to the normal, d refers to the displacement. '.' means dot product. '*' means cross product
 
             Vector3 v1, v2, v3;
-            float f = -Vector3.Dot(a.Normal, Vector3.Cross(b.Normal, c.Normal));
+            float f = -Vector3.Dot(a.normal, Vector3.Cross(b.normal, c.normal));
 
-            v1 = (a.D * (Vector3.Cross(b.Normal, c.Normal)));
-            v2 = (b.D * (Vector3.Cross(c.Normal, a.Normal)));
-            v3 = (c.D * (Vector3.Cross(a.Normal, b.Normal)));
+            v1 = (a.distance * (Vector3.Cross(b.normal, c.normal)));
+            v2 = (b.distance * (Vector3.Cross(c.normal, a.normal)));
+            v3 = (c.distance * (Vector3.Cross(a.normal, b.normal)));
 
-            Vector3 vec = new Vector3(v1.X + v2.X + v3.X, v1.Y + v2.Y + v3.Y, v1.Z + v2.Z + v3.Z);
+            Vector3 vec = new Vector3(v1.x + v2.x + v3.x, v1.y + v2.y + v3.y, v1.z + v2.z + v3.z);
             return vec / f;
         }
 
-        private void NormalizePlane(ref Plane p)
+        private void normalizePlane(ref Plane p)
         {
-            float factor = 1f / p.Normal.Length();
-            p.Normal.X *= factor;
-            p.Normal.Y *= factor;
-            p.Normal.Z *= factor;
-            p.D *= factor;
+            float factor = 1f / p.normal.magnitude;
+
+            Vector3 normal = new Vector3(p.normal.x * factor, p.normal.y * factor, p.normal.z * factor);
+            //p.normal.x *= factor;
+            //p.normal.y *= factor;
+            //p.normal.z *= factor;
+            p.normal = normal;
+            p.distance *= factor;
         }
 
         #endregion

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs
@@ -1,0 +1,515 @@
+﻿#region License
+/*
+MIT License
+Copyright © 2006 The Mono.Xna Team
+
+All rights reserved.
+
+Authors:
+Olivier Dufour (Duff)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion License
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    [Serializable, TypeConverter(typeof(ExpandableObjectConverter))]
+    public class BoundingFrustum : IEquatable<BoundingFrustum>
+    {
+        #region Private Fields
+
+        private Matrix matrix;
+        private Plane bottom;
+        private Plane far;
+        private Plane left;
+        private Plane right;
+        private Plane near;
+        private Plane top;
+        private Vector3[] corners;
+
+        #endregion Private Fields
+
+        #region Public Fields
+        public const int CornerCount = 8;
+        #endregion
+
+        #region Public Constructors
+
+        public BoundingFrustum(Matrix value)
+        {
+            this.matrix = value;
+            CreatePlanes();
+            CreateCorners();
+        }
+
+        #endregion Public Constructors
+
+
+        #region Public Properties
+
+        public Plane Bottom
+        {
+            get { return this.bottom; }
+        }
+
+        public Plane Far
+        {
+            get { return this.far; }
+        }
+
+        public Plane Left
+        {
+            get { return this.left; }
+        }
+
+        public Matrix Matrix
+        {
+            get { return this.matrix; }
+            set
+            {
+                this.matrix = value;
+                this.CreatePlanes();    // FIXME: The odds are the planes will be used a lot more often than the matrix
+                this.CreateCorners();   // is updated, so this should help performance. I hope ;)
+            }
+        }
+
+        public Plane Near
+        {
+            get { return this.near; }
+        }
+
+        public Plane Right
+        {
+            get { return this.right; }
+        }
+
+        public Plane Top
+        {
+            get { return this.top; }
+        }
+
+        #endregion Public Properties
+
+
+        #region Public Methods
+
+        public static bool operator ==(BoundingFrustum a, BoundingFrustum b)
+        {
+            if (object.Equals(a, null))
+                return (object.Equals(b, null));
+
+            if (object.Equals(b, null))
+                return (object.Equals(a, null));
+
+            return a.matrix == (b.matrix);
+        }
+
+        public static bool operator !=(BoundingFrustum a, BoundingFrustum b)
+        {
+            return !(a == b);
+        }
+
+        public ContainmentType Contains(BoundingBox box)
+        {
+            ContainmentType result;
+            this.Contains(ref box, out result);
+            return result;
+        }
+
+        public void GetCorners(Vector3[] corners)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Contains(ref BoundingBox box, out ContainmentType result)
+        {
+            // FIXME: Is this a bug?
+            // If the bounding box is of W * D * H = 0, then return disjoint
+            if (box.Min == box.Max)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            int i;
+            ContainmentType contained;
+            Vector3[] corners = box.GetCorners();
+
+            // First we assume completely disjoint. So if we find a point that is contained, we break out of this loop
+            for (i = 0; i < corners.Length; i++)
+            {
+                this.Contains(ref corners[i], out contained);
+                if (contained != ContainmentType.Disjoint)
+                    break;
+            }
+
+            if (i == corners.Length) // This means we checked all the corners and they were all disjoint
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            if (i != 0)             // if i is not equal to zero, we can fastpath and say that this box intersects
+            {                       // because we know at least one point is outside and one is inside.
+                result = ContainmentType.Intersects;
+                return;
+            }
+
+            // If we get here, it means the first (and only) point we checked was actually contained in the frustum.
+            // So we assume that all other points will also be contained. If one of the points is disjoint, we can
+            // exit immediately saying that the result is Intersects
+            i++;
+            for (; i < corners.Length; i++)
+            {
+                this.Contains(ref corners[i], out contained);
+                if (contained != ContainmentType.Contains)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+            }
+
+            // If we get here, then we know all the points were actually contained, therefore result is Contains
+            result = ContainmentType.Contains;
+            return;
+        }
+
+        // TODO: Implement this
+        public ContainmentType Contains(BoundingFrustum frustum)
+        {
+            if (this == frustum)                // We check to see if the two frustums are equal
+                return ContainmentType.Contains;// If they are, there's no need to go any further.
+
+            throw new NotImplementedException();
+        }
+
+        public ContainmentType Contains(BoundingSphere sphere)
+        {
+            ContainmentType result;
+            this.Contains(ref sphere, out result);
+            return result;
+        }
+
+        public void Contains(ref BoundingSphere sphere, out ContainmentType result)
+        {
+            float val;
+            ContainmentType contained;
+
+            // We first check if the sphere is inside the frustum
+            this.Contains(ref sphere.Center, out contained);
+
+            // The sphere is inside. Now we need to check if it's fully contained or not
+            // So we see if the perpendicular distance to each plane is less than or equal to the sphere's radius.
+            // If the perpendicular distance is less, just return Intersects.
+            if (contained == ContainmentType.Contains)
+            {
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.bottom);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.far);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.left);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.near);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.right);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                val = PlaneHelper.PerpendicularDistance(ref sphere.Center, ref this.top);
+                if (val < sphere.Radius)
+                {
+                    result = ContainmentType.Intersects;
+                    return;
+                }
+
+                // If we get here, the sphere is fully contained
+                result = ContainmentType.Contains;
+                return;
+            }
+            //duff idea : test if all corner is in same side of a plane if yes and outside it is disjoint else intersect
+            // issue is that we can have some times when really close aabb 
+
+
+
+            // If we're here, the the sphere's centre was outside of the frustum. This makes things hard :(
+            // We can't use perpendicular distance anymore. I'm not sure how to code this.
+            throw new NotImplementedException();
+        }
+
+        public ContainmentType Contains(Vector3 point)
+        {
+            ContainmentType result;
+            this.Contains(ref point, out result);
+            return result;
+        }
+
+        public void Contains(ref Vector3 point, out ContainmentType result)
+        {
+            float val;
+            // If a point is on the POSITIVE side of the plane, then the point is not contained within the frustum
+
+            // Check the top
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.top);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // Check the bottom
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.bottom);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // Check the left
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.left);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // Check the right
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.right);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // Check the near
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.near);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // Check the far
+            val = PlaneHelper.ClassifyPoint(ref point, ref this.far);
+            if (val > 0)
+            {
+                result = ContainmentType.Disjoint;
+                return;
+            }
+
+            // If we get here, it means that the point was on the correct side of each plane to be
+            // contained. Therefore this point is contained
+            result = ContainmentType.Contains;
+        }
+
+        public bool Equals(BoundingFrustum other)
+        {
+            return (this == other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            BoundingFrustum f = obj as BoundingFrustum;
+            return (object.Equals(f, null)) ? false : (this == f);
+        }
+
+        public Vector3[] GetCorners()
+        {
+            return corners;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.matrix.GetHashCode();
+        }
+
+        public bool Intersects(BoundingBox box)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Intersects(ref BoundingBox box, out bool result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Intersects(BoundingFrustum frustum)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Intersects(BoundingSphere sphere)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Intersects(ref BoundingSphere sphere, out bool result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public PlaneIntersectionType Intersects(Plane plane)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Intersects(ref Plane plane, out PlaneIntersectionType result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Nullable<float> Intersects(Ray ray)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Intersects(ref Ray ray, out Nullable<float> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(256);
+            sb.Append("{Near:");
+            sb.Append(this.near.ToString());
+            sb.Append(" Far:");
+            sb.Append(this.far.ToString());
+            sb.Append(" Left:");
+            sb.Append(this.left.ToString());
+            sb.Append(" Right:");
+            sb.Append(this.right.ToString());
+            sb.Append(" Top:");
+            sb.Append(this.top.ToString());
+            sb.Append(" Bottom:");
+            sb.Append(this.bottom.ToString());
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        #endregion Public Methods
+
+
+        #region Private Methods
+
+#warning Move this to the PlaneHelper class
+        private void CreateCorners()
+        {
+            this.corners = new Vector3[8];
+            this.corners[0] = IntersectionPoint(ref this.near, ref this.left, ref this.top);
+            this.corners[1] = IntersectionPoint(ref this.near, ref this.right, ref this.top);
+            this.corners[2] = IntersectionPoint(ref this.near, ref this.right, ref this.bottom);
+            this.corners[3] = IntersectionPoint(ref this.near, ref this.left, ref this.bottom);
+            this.corners[4] = IntersectionPoint(ref this.far, ref this.left, ref this.top);
+            this.corners[5] = IntersectionPoint(ref this.far, ref this.right, ref this.top);
+            this.corners[6] = IntersectionPoint(ref this.far, ref this.right, ref this.bottom);
+            this.corners[7] = IntersectionPoint(ref this.far, ref this.left, ref this.bottom);
+        }
+
+        private void CreatePlanes()
+        {
+            // Pre-calculate the different planes needed
+            this.left = new Plane(-this.matrix.M14 - this.matrix.M11, -this.matrix.M24 - this.matrix.M21,
+                                  -this.matrix.M34 - this.matrix.M31, -this.matrix.M44 - this.matrix.M41);
+
+            this.right = new Plane(this.matrix.M11 - this.matrix.M14, this.matrix.M21 - this.matrix.M24,
+                                   this.matrix.M31 - this.matrix.M34, this.matrix.M41 - this.matrix.M44);
+
+            this.top = new Plane(this.matrix.M12 - this.matrix.M14, this.matrix.M22 - this.matrix.M24,
+                                 this.matrix.M32 - this.matrix.M34, this.matrix.M42 - this.matrix.M44);
+
+            this.bottom = new Plane(-this.matrix.M14 - this.matrix.M12, -this.matrix.M24 - this.matrix.M22,
+                                    -this.matrix.M34 - this.matrix.M32, -this.matrix.M44 - this.matrix.M42);
+
+            this.near = new Plane(-this.matrix.M13, -this.matrix.M23, -this.matrix.M33, -this.matrix.M43);
+
+
+            this.far = new Plane(this.matrix.M13 - this.matrix.M14, this.matrix.M23 - this.matrix.M24,
+                                 this.matrix.M33 - this.matrix.M34, this.matrix.M43 - this.matrix.M44);
+
+            this.NormalizePlane(ref this.left);
+            this.NormalizePlane(ref this.right);
+            this.NormalizePlane(ref this.top);
+            this.NormalizePlane(ref this.bottom);
+            this.NormalizePlane(ref this.near);
+            this.NormalizePlane(ref this.far);
+        }
+
+        private static Vector3 IntersectionPoint(ref Plane a, ref Plane b, ref Plane c)
+        {
+            // Formula used
+            //                d1 ( N2 * N3 ) + d2 ( N3 * N1 ) + d3 ( N1 * N2 )
+            //P =       -------------------------------------------------------------------------
+            //                             N1 . ( N2 * N3 )
+            //
+            // Note: N refers to the normal, d refers to the displacement. '.' means dot product. '*' means cross product
+
+            Vector3 v1, v2, v3;
+            float f = -Vector3.Dot(a.Normal, Vector3.Cross(b.Normal, c.Normal));
+
+            v1 = (a.D * (Vector3.Cross(b.Normal, c.Normal)));
+            v2 = (b.D * (Vector3.Cross(c.Normal, a.Normal)));
+            v3 = (c.D * (Vector3.Cross(a.Normal, b.Normal)));
+
+            Vector3 vec = new Vector3(v1.X + v2.X + v3.X, v1.Y + v2.Y + v3.Y, v1.Z + v2.Z + v3.Z);
+            return vec / f;
+        }
+
+        private void NormalizePlane(ref Plane p)
+        {
+            float factor = 1f / p.Normal.Length();
+            p.Normal.X *= factor;
+            p.Normal.Y *= factor;
+            p.Normal.Z *= factor;
+            p.D *= factor;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingFrustrum.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5c34e575793f6834cb229a58ec8d4185
+timeCreated: 1429899092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingSphere.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingSphere.cs
@@ -1,0 +1,363 @@
+﻿#region License
+/*
+MIT License
+Copyright © 2006 The Mono.Xna Team
+
+All rights reserved.
+
+Authors:
+Olivier Dufour (Duff)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion License
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    public struct BoundingSphere : IEquatable<BoundingSphere>
+    {
+        #region Public Fields
+
+        public Vector3 Center;
+        public float Radius;
+
+        #endregion Public Fields
+
+
+        #region Constructors
+
+        public BoundingSphere(Vector3 center, float radius)
+        {
+            this.Center = center;
+            this.Radius = radius;
+        }
+
+        #endregion Constructors
+
+
+        #region Public Methods
+
+        public BoundingSphere Transform(Matrix matrix)
+        {
+            BoundingSphere sphere = new BoundingSphere();
+            sphere.Center = Vector3Helper.Transform(ref this.Center, matrix);
+            sphere.Radius = this.Radius * ((float)Math.Sqrt((double)Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33)))));
+            return sphere;
+        }
+
+        public void Transform(ref Matrix matrix, out BoundingSphere result)
+        {
+            result.Center = Vector3Helper.Transform(ref this.Center, matrix);
+            result.Radius = this.Radius * ((float)Math.Sqrt((double)Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33)))));
+        }
+
+        public ContainmentType Contains(BoundingBox box)
+        {
+            //check if all corner is in sphere
+            bool inside = true;
+            foreach (Vector3 corner in box.GetCorners())
+            {
+                if (this.Contains(corner) == ContainmentType.Disjoint)
+                {
+                    inside = false;
+                    break;
+                }
+            }
+
+            if (inside)
+                return ContainmentType.Contains;
+
+            //check if the distance from sphere center to cube face < radius
+            double dmin = 0;
+
+            if (Center.x < box.Min.x)
+                dmin += (Center.x - box.Min.x) * (Center.x - box.Min.x);
+
+            else if (Center.x > box.Max.x)
+                dmin += (Center.x - box.Max.x) * (Center.x - box.Max.x);
+
+            if (Center.y < box.Min.y)
+                dmin += (Center.y - box.Min.y) * (Center.y - box.Min.y);
+
+            else if (Center.y > box.Max.y)
+                dmin += (Center.y - box.Max.y) * (Center.y - box.Max.y);
+
+            if (Center.z < box.Min.z)
+                dmin += (Center.z - box.Min.z) * (Center.z - box.Min.z);
+
+            else if (Center.z > box.Max.z)
+                dmin += (Center.z - box.Max.z) * (Center.z - box.Max.z);
+
+            if (dmin <= Radius * Radius)
+                return ContainmentType.Intersects;
+
+            //else disjoint
+            return ContainmentType.Disjoint;
+
+        }
+
+        public void Contains(ref BoundingBox box, out ContainmentType result)
+        {
+            result = this.Contains(box);
+        }
+
+        public ContainmentType Contains(BoundingFrustum frustum)
+        {
+            //check if all corner is in sphere
+            bool inside = true;
+
+            Vector3[] corners = frustum.GetCorners();
+            foreach (Vector3 corner in corners)
+            {
+                if (this.Contains(corner) == ContainmentType.Disjoint)
+                {
+                    inside = false;
+                    break;
+                }
+            }
+            if (inside)
+                return ContainmentType.Contains;
+
+            //check if the distance from sphere center to frustrum face < radius
+            double dmin = 0;
+            //TODO : calcul dmin
+
+            if (dmin <= Radius * Radius)
+                return ContainmentType.Intersects;
+
+            //else disjoint
+            return ContainmentType.Disjoint;
+        }
+
+        public ContainmentType Contains(BoundingSphere sphere)
+        {
+            float val = Vector3.Distance(sphere.Center, Center);
+
+            if (val > sphere.Radius + Radius)
+                return ContainmentType.Disjoint;
+
+            else if (val <= Radius - sphere.Radius)
+                return ContainmentType.Contains;
+
+            else
+                return ContainmentType.Intersects;
+        }
+
+        public void Contains(ref BoundingSphere sphere, out ContainmentType result)
+        {
+            result = Contains(sphere);
+        }
+
+        public ContainmentType Contains(Vector3 point)
+        {
+            float distance = Vector3.Distance(point, Center);
+
+            if (distance > this.Radius)
+                return ContainmentType.Disjoint;
+
+            else if (distance < this.Radius)
+                return ContainmentType.Contains;
+
+            return ContainmentType.Intersects;
+        }
+
+        public void Contains(ref Vector3 point, out ContainmentType result)
+        {
+            result = Contains(point);
+        }
+
+        public static BoundingSphere CreateFromBoundingBox(BoundingBox box)
+        {
+            // Find the center of the box.
+            Vector3 center = new Vector3((box.Min.x + box.Max.x) / 2.0f,
+                                         (box.Min.y + box.Max.y) / 2.0f,
+                                         (box.Min.z + box.Max.z) / 2.0f);
+
+            // Find the distance between the center and one of the corners of the box.
+            float radius = Vector3.Distance(center, box.Max);
+
+            return new BoundingSphere(center, radius);
+        }
+
+        public static void CreateFromBoundingBox(ref BoundingBox box, out BoundingSphere result)
+        {
+            result = CreateFromBoundingBox(box);
+        }
+
+        public static BoundingSphere CreateFromFrustum(BoundingFrustum frustum)
+        {
+            return BoundingSphere.CreateFromPoints(frustum.GetCorners());
+        }
+
+        public static BoundingSphere CreateFromPoints(IEnumerable<Vector3> points)
+        {
+            if (points == null)
+                throw new ArgumentNullException("points");
+
+            float radius = 0;
+            Vector3 center = new Vector3();
+            // First, we'll find the center of gravity for the point 'cloud'.
+            int num_points = 0; // The number of points (there MUST be a better way to get this instead of counting the number of points one by one?)
+
+            foreach (Vector3 v in points)
+            {
+                center += v;    // If we actually knew the number of points, we'd get better accuracy by adding v / num_points.
+                ++num_points;
+            }
+
+            center /= (float)num_points;
+
+            // Calculate the radius of the needed sphere (it equals the distance between the center and the point further away).
+            foreach (Vector3 v in points)
+            {
+                float distance = ((Vector3)(v - center)).magnitude;
+
+                if (distance > radius)
+                    radius = distance;
+            }
+
+            return new BoundingSphere(center, radius);
+        }
+
+        public static BoundingSphere CreateMerged(BoundingSphere original, BoundingSphere additional)
+        {
+            Vector3 ocenterToaCenter = additional.Center - original.Center;
+            float distance = ocenterToaCenter.magnitude;
+            if (distance <= original.Radius + additional.Radius)//intersect
+            {
+                if (distance <= original.Radius - additional.Radius)//original contain additional
+                    return original;
+                if (distance <= additional.Radius - original.Radius)//additional contain original
+                    return additional;
+            }
+
+            //else find center of new sphere and radius
+            float leftRadius = Math.Max(original.Radius - distance, additional.Radius);
+            float Rightradius = Math.Max(original.Radius + distance, additional.Radius);
+            ocenterToaCenter = ocenterToaCenter + (((leftRadius - Rightradius) / (2 * ocenterToaCenter.magnitude)) * ocenterToaCenter);//oCenterToResultCenter
+
+            BoundingSphere result = new BoundingSphere();
+            result.Center = original.Center + ocenterToaCenter;
+            result.Radius = (leftRadius + Rightradius) / 2;
+            return result;
+        }
+
+        public static void CreateMerged(ref BoundingSphere original, ref BoundingSphere additional, out BoundingSphere result)
+        {
+            result = BoundingSphere.CreateMerged(original, additional);
+        }
+
+        public bool Equals(BoundingSphere other)
+        {
+            return this.Center == other.Center && this.Radius == other.Radius;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is BoundingSphere)
+                return this.Equals((BoundingSphere)obj);
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Center.GetHashCode() + this.Radius.GetHashCode();
+        }
+
+        public bool Intersects(BoundingBox box)
+        {
+            return box.Intersects(this);
+        }
+
+        public void Intersects(ref BoundingBox box, out bool result)
+        {
+            result = Intersects(box);
+        }
+
+        public bool Intersects(BoundingFrustum frustum)
+        {
+            if (frustum == null)
+                throw new NullReferenceException();
+
+            throw new NotImplementedException();
+        }
+
+        public bool Intersects(BoundingSphere sphere)
+        {
+            float val = Vector3.Distance(sphere.Center, Center);
+            if (val > sphere.Radius + Radius)
+                return false;
+            return true;
+        }
+
+        public void Intersects(ref BoundingSphere sphere, out bool result)
+        {
+            result = Intersects(sphere);
+        }
+
+        public PlaneIntersectionType Intersects(Plane plane)
+        {
+            float distance = Vector3.Dot(plane.normal, this.Center) + plane.distance;
+            if (distance > this.Radius)
+                return PlaneIntersectionType.Front;
+            if (distance < -this.Radius)
+                return PlaneIntersectionType.Back;
+            //else it intersect
+            return PlaneIntersectionType.Intersecting;
+        }
+
+        public void Intersects(ref Plane plane, out PlaneIntersectionType result)
+        {
+            result = Intersects(plane);
+        }
+
+        public Nullable<float> Intersects(Ray ray)
+        {
+            return ray.Intersects(this);
+        }
+
+        public void Intersects(ref Ray ray, out Nullable<float> result)
+        {
+            result = Intersects(ray);
+        }
+
+        public static bool operator ==(BoundingSphere a, BoundingSphere b)
+        {
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(BoundingSphere a, BoundingSphere b)
+        {
+            return !a.Equals(b);
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentCulture, "{{Center:{0} Radius:{1}}}", this.Center.ToString(), this.Radius.ToString());
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/BoundingSphere.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/BoundingSphere.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6f8a7ba062b266c49ad16c59eb7edbef
+timeCreated: 1429899092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/Enums.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Enums.cs
@@ -1,0 +1,101 @@
+﻿#region License
+/*
+MIT License
+Copyright © 2006 - 2007 The Mono.Xna Team
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion License
+
+using System;
+
+namespace Microsoft.Xna.Framework
+{
+    public enum PowerLineStatus
+    {
+        Offline,
+        Online,
+        Unknown
+    }
+
+    [Flags]
+    public enum BatteryChargeStatus
+    {
+        Charging = 8,
+        Critical = 4,
+        High = 1,
+        Low = 2,
+        NoSystemBattery = 0x80,
+        Unknown = 0xff
+    }
+
+    public enum PlayerIndex
+    {
+        One,
+        Two,
+        Three,
+        Four
+    }
+
+    public enum CurveLoopType
+    {
+        Constant,
+        Cycle,
+        CycleOffset,
+        Oscillate,
+        Linear
+    }
+
+    public enum CurveContinuity
+    {
+        Smooth,
+        Step
+    }
+
+    public enum CurveTangent
+    {
+        Flat,
+        Linear,
+        Smooth
+    }
+
+    public enum TargetPlatform
+    {
+        Unknown,
+        Windows,
+        Xbox360,
+        Zune
+    }
+
+    public enum PlaneIntersectionType
+    {
+        Front,
+        Back,
+        Intersecting
+    }
+
+    public enum ContainmentType
+    {
+        Disjoint,
+        Contains,
+        Intersects
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/Enums.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Enums.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 22b7d39d3fa5eab4ba76897eaba13140
+timeCreated: 1429899091
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    public static class Extensions
+    {
+        public static Vector3 Transform(this Vector3 position, Matrix matrix)
+        {
+            Transform(ref position, ref matrix, out position);
+            return position;
+        }
+
+        public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
+        {
+            result = new Vector3((position.x * matrix.M11) + (position.y * matrix.M21) + (position.z * matrix.M31) + matrix.M41,
+                                 (position.x * matrix.M12) + (position.y * matrix.M22) + (position.z * matrix.M32) + matrix.M42,
+                                 (position.x * matrix.M13) + (position.y * matrix.M23) + (position.z * matrix.M33) + matrix.M43);
+        }
+
+        public static Vector3 Normalize(this Vector3 value)
+        {
+            float factor = 1f / (float)Math.Sqrt((double)(value.x * value.x + value.y * value.y + value.z * value.z));
+            value.x *= factor;
+            value.y *= factor;
+            value.z *= factor;
+            return value;
+        }
+
+        public static float? Intersects(this Ray ray, BoundingBox box)
+        {
+            //first test if start in box
+            if (ray.origin.x >= box.Min.x
+                    && ray.origin.x <= box.Max.x
+                    && ray.origin.y >= box.Min.y
+                    && ray.origin.y <= box.Max.y
+                    && ray.origin.z >= box.Min.z
+                    && ray.origin.z <= box.Max.z)
+                return 0.0f;// here we concidere cube is full and origine is in cube so intersect at origine
+
+            //Second we check each face
+            Vector3 maxT = new Vector3(-1.0f, -1.0f, -1.0f);
+            //Vector3 minT = new Vector3(-1.0f);
+            //calcul intersection with each faces
+            if (ray.origin.x < box.Min.x && ray.direction.x != 0.0f)
+                maxT.x = (box.Min.x - ray.origin.x) / ray.direction.x;
+            else if (ray.origin.x > box.Max.x && ray.direction.x != 0.0f)
+                maxT.x = (box.Max.x - ray.origin.x) / ray.direction.x;
+            if (ray.origin.y < box.Min.y && ray.direction.y != 0.0f)
+                maxT.y = (box.Min.y - ray.origin.y) / ray.direction.y;
+            else if (ray.origin.y > box.Max.y && ray.direction.y != 0.0f)
+                maxT.y = (box.Max.y - ray.origin.y) / ray.direction.y;
+            if (ray.origin.z < box.Min.z && ray.direction.z != 0.0f)
+                maxT.z = (box.Min.z - ray.origin.z) / ray.direction.z;
+            else if (ray.origin.z > box.Max.z && ray.direction.z != 0.0f)
+                maxT.z = (box.Max.z - ray.origin.z) / ray.direction.z;
+
+            //get the maximum maxT
+            if (maxT.x > maxT.y && maxT.x > maxT.z)
+            {
+                if (maxT.x < 0.0f)
+                    return null;// ray go on opposite of face
+                //coordonate of hit point of face of cube
+                float coord = ray.origin.z + maxT.x * ray.direction.z;
+                // if hit point coord ( intersect face with ray) is out of other plane coord it miss 
+                if (coord < box.Min.z || coord > box.Max.z)
+                    return null;
+                coord = ray.origin.y + maxT.x * ray.direction.y;
+                if (coord < box.Min.y || coord > box.Max.y)
+                    return null;
+                return maxT.x;
+            }
+            if (maxT.y > maxT.x && maxT.y > maxT.z)
+            {
+                if (maxT.y < 0.0f)
+                    return null;// ray go on opposite of face
+                //coordonate of hit point of face of cube
+                float coord = ray.origin.z + maxT.y * ray.direction.z;
+                // if hit point coord ( intersect face with ray) is out of other plane coord it miss 
+                if (coord < box.Min.z || coord > box.Max.z)
+                    return null;
+                coord = ray.origin.x + maxT.y * ray.direction.x;
+                if (coord < box.Min.x || coord > box.Max.x)
+                    return null;
+                return maxT.y;
+            }
+            else //Z
+            {
+                if (maxT.z < 0.0f)
+                    return null;// ray go on opposite of face
+                //coordonate of hit point of face of cube
+                float coord = ray.origin.x + maxT.z * ray.direction.x;
+                // if hit point coord ( intersect face with ray) is out of other plane coord it miss 
+                if (coord < box.Min.x || coord > box.Max.x)
+                    return null;
+                coord = ray.origin.y + maxT.z * ray.direction.y;
+                if (coord < box.Min.y || coord > box.Max.y)
+                    return null;
+                return maxT.z;
+            }
+        }
+
+
+        //public void Intersects(ref BoundingBox box, out float? result)
+        //{
+        //    result = Intersects(box);
+        //}
+
+
+        //public float? Intersects(BoundingFrustum frustum)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+
+        //public float? Intersects(BoundingSphere sphere)
+        //{
+        //    float? result;
+        //    Intersects(ref sphere, out result);
+        //    return result;
+        //}
+
+        //public float? Intersects(Plane plane)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public void Intersects(ref Plane plane, out float? result)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        public static void Intersects(this Ray ray, ref BoundingSphere sphere, out float? result)
+        {
+            // Find the vector between where the ray starts the the sphere's centre
+            Vector3 difference = sphere.Center - ray.origin;
+
+            float differenceLengthSquared = difference.sqrMagnitude;
+            float sphereRadiusSquared = sphere.Radius * sphere.Radius;
+
+            float distanceAlongRay;
+
+            // If the distance between the ray start and the sphere's centre is less than
+            // the radius of the sphere, it means we've intersected. N.B. checking the LengthSquared is faster.
+            if (differenceLengthSquared < sphereRadiusSquared)
+            {
+                result = 0.0f;
+                return;
+            }
+
+            //Vector3Helper.Dot(ref this.Direction, ref difference, out distanceAlongRay);
+            distanceAlongRay = Vector3Helper.Dot(ray.direction, difference);
+            // If the ray is pointing away from the sphere then we don't ever intersect
+            if (distanceAlongRay < 0)
+            {
+                result = null;
+                return;
+            }
+
+            // Next we kinda use Pythagoras to check if we are within the bounds of the sphere
+            // if x = radius of sphere
+            // if y = distance between ray position and sphere centre
+            // if z = the distance we've travelled along the ray
+            // if x^2 + z^2 - y^2 < 0, we do not intersect
+            float dist = sphereRadiusSquared + distanceAlongRay * distanceAlongRay - differenceLengthSquared;
+
+            result = (dist < 0) ? null : distanceAlongRay - (float?)Math.Sqrt(dist);
+        }
+        
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs
@@ -133,8 +133,10 @@ namespace Microsoft.Xna.Framework
         //    throw new NotImplementedException();
         //}
 
-        public static void Intersects(this Ray ray, ref BoundingSphere sphere, out float? result)
+        public static float? Intersects(this Ray ray, BoundingSphere sphere)
         {
+            float? result = null;
+
             // Find the vector between where the ray starts the the sphere's centre
             Vector3 difference = sphere.Center - ray.origin;
 
@@ -147,8 +149,7 @@ namespace Microsoft.Xna.Framework
             // the radius of the sphere, it means we've intersected. N.B. checking the LengthSquared is faster.
             if (differenceLengthSquared < sphereRadiusSquared)
             {
-                result = 0.0f;
-                return;
+                return result = 0.0f;
             }
 
             //Vector3Helper.Dot(ref this.Direction, ref difference, out distanceAlongRay);
@@ -156,8 +157,7 @@ namespace Microsoft.Xna.Framework
             // If the ray is pointing away from the sphere then we don't ever intersect
             if (distanceAlongRay < 0)
             {
-                result = null;
-                return;
+                return result = null;
             }
 
             // Next we kinda use Pythagoras to check if we are within the bounds of the sphere
@@ -167,7 +167,7 @@ namespace Microsoft.Xna.Framework
             // if x^2 + z^2 - y^2 < 0, we do not intersect
             float dist = sphereRadiusSquared + distanceAlongRay * distanceAlongRay - differenceLengthSquared;
 
-            result = (dist < 0) ? null : distanceAlongRay - (float?)Math.Sqrt(dist);
+            return result = (dist < 0) ? null : distanceAlongRay - (float?)Math.Sqrt(dist);
         }
         
     }

--- a/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Extensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7a7b1be935db70b44be5c2ceda587bd5
+timeCreated: 1429899092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 97743be9820360542866da8deb852e91
+folderAsset: yes
+timeCreated: 1429899091
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    internal class PlaneHelper
+    {
+        /// <summary>
+        /// Returns a value indicating what side (positive/negative) of a plane a point is
+        /// </summary>
+        /// <param name="point">The point to check with</param>
+        /// <param name="plane">The plane to check against</param>
+        /// <returns>Greater than zero if on the positive side, less than zero if on the negative size, 0 otherwise</returns>
+        public static float ClassifyPoint(ref Vector3 point, ref Plane plane)
+        {
+            return point.x * plane.normal.x + point.y * plane.normal.y + point.z * plane.normal.z + plane.distance;
+        }
+
+        /// <summary>
+        /// Returns the perpendicular distance from a point to a plane
+        /// </summary>
+        /// <param name="point">The point to check</param>
+        /// <param name="plane">The place to check</param>
+        /// <returns>The perpendicular distance from the point to the plane</returns>
+        public static float PerpendicularDistance(ref Vector3 point, ref Plane plane)
+        {
+            // dist = (ax + by + cz + d) / sqrt(a*a + b*b + c*c)
+            return (float)Math.Abs((plane.normal.x * point.x + plane.normal.y * point.y + plane.normal.z * point.z)
+                                    / Math.Sqrt(plane.normal.x * plane.normal.x + plane.normal.y * plane.normal.y + plane.normal.z * plane.normal.z));
+        }
+
+        public static Plane Normalize(Plane value)
+        {
+            Plane ret;
+            Normalize(ref value, out ret);
+            return ret;
+        }
+
+        public static void Normalize(ref Plane value, out Plane result)
+        {
+            float factor;
+            result.normal = Vector3.Normalize(value.normal);
+            factor = (float)Math.Sqrt(result.normal.x * result.normal.x + result.normal.y * result.normal.y + result.normal.z * result.normal.z) /
+                            (float)Math.Sqrt(value.normal.x * value.normal.x + value.normal.y * value.normal.y + value.normal.z * value.normal.z);
+            result.distance = value.distance * factor;
+        }
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs
@@ -33,18 +33,21 @@ namespace Microsoft.Xna.Framework
 
         public static Plane Normalize(Plane value)
         {
-            Plane ret;
-            Normalize(ref value, out ret);
-            return ret;
+            return Normalize(value);
         }
 
-        public static void Normalize(ref Plane value, out Plane result)
+        public static Plane Normalize(ref Plane value)
         {
+            Plane result = new Plane();
+
             float factor;
+
             result.normal = Vector3.Normalize(value.normal);
             factor = (float)Math.Sqrt(result.normal.x * result.normal.x + result.normal.y * result.normal.y + result.normal.z * result.normal.z) /
                             (float)Math.Sqrt(value.normal.x * value.normal.x + value.normal.y * value.normal.y + value.normal.z * value.normal.z);
             result.distance = value.distance * factor;
+
+            return result;
         }
     }
 }

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/PlaneHelper.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 84222369545d1014e982a0615bd8ba0a
+timeCreated: 1429899092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/QuaternionHelper.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/QuaternionHelper.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    internal class QuaternionHelper
+    {
+        public static Quaternion CreateFromRotationMatrix(Matrix matrix)
+        {
+            Quaternion result;
+            if ((matrix.M11 + matrix.M22 + matrix.M33) > 0.0F)
+            {
+                float M1 = (float)System.Math.Sqrt((double)(matrix.M11 + matrix.M22 + matrix.M33 + 1.0F));
+                result.w = M1 * 0.5F;
+                M1 = 0.5F / M1;
+                result.x = (matrix.M23 - matrix.M32) * M1;
+                result.y = (matrix.M31 - matrix.M13) * M1;
+                result.z = (matrix.M12 - matrix.M21) * M1;
+                return result;
+            }
+            if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
+            {
+                float M2 = (float)System.Math.Sqrt((double)(1.0F + matrix.M11 - matrix.M22 - matrix.M33));
+                float M3 = 0.5F / M2;
+                result.x = 0.5F * M2;
+                result.y = (matrix.M12 + matrix.M21) * M3;
+                result.z = (matrix.M13 + matrix.M31) * M3;
+                result.w = (matrix.M23 - matrix.M32) * M3;
+                return result;
+            }
+            if (matrix.M22 > matrix.M33)
+            {
+                float M4 = (float)System.Math.Sqrt((double)(1.0F + matrix.M22 - matrix.M11 - matrix.M33));
+                float M5 = 0.5F / M4;
+                result.x = (matrix.M21 + matrix.M12) * M5;
+                result.y = 0.5F * M4;
+                result.z = (matrix.M32 + matrix.M23) * M5;
+                result.w = (matrix.M31 - matrix.M13) * M5;
+                return result;
+            }
+            float M6 = (float)System.Math.Sqrt((double)(1.0F + matrix.M33 - matrix.M11 - matrix.M22));
+            float M7 = 0.5F / M6;
+            result.x = (matrix.M31 + matrix.M13) * M7;
+            result.y = (matrix.M32 + matrix.M23) * M7;
+            result.z = 0.5F * M6;
+            result.w = (matrix.M12 - matrix.M21) * M7;
+            return result;
+        }
+
+        public static Quaternion CreateFromYawPitchRoll(float yaw, float pitch, float roll)
+        {
+            Quaternion quaternion;
+            quaternion.x = (((float)Math.Cos((double)(yaw * 0.5f)) * (float)Math.Sin((double)(pitch * 0.5f))) * (float)Math.Cos((double)(roll * 0.5f))) + (((float)Math.Sin((double)(yaw * 0.5f)) * (float)Math.Cos((double)(pitch * 0.5f))) * (float)Math.Sin((double)(roll * 0.5f)));
+            quaternion.y = (((float)Math.Sin((double)(yaw * 0.5f)) * (float)Math.Cos((double)(pitch * 0.5f))) * (float)Math.Cos((double)(roll * 0.5f))) - (((float)Math.Cos((double)(yaw * 0.5f)) * (float)Math.Sin((double)(pitch * 0.5f))) * (float)Math.Sin((double)(roll * 0.5f)));
+            quaternion.z = (((float)Math.Cos((double)(yaw * 0.5f)) * (float)Math.Cos((double)(pitch * 0.5f))) * (float)Math.Sin((double)(roll * 0.5f))) - (((float)Math.Sin((double)(yaw * 0.5f)) * (float)Math.Sin((double)(pitch * 0.5f))) * (float)Math.Cos((double)(roll * 0.5f)));
+            quaternion.w = (((float)Math.Cos((double)(yaw * 0.5f)) * (float)Math.Cos((double)(pitch * 0.5f))) * (float)Math.Cos((double)(roll * 0.5f))) + (((float)Math.Sin((double)(yaw * 0.5f)) * (float)Math.Sin((double)(pitch * 0.5f))) * (float)Math.Sin((double)(roll * 0.5f)));
+            return quaternion;
+        }
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/QuaternionHelper.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/QuaternionHelper.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b5d5f27dfd5f97f4b9f6fe04dc07e522
+timeCreated: 1429901520
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/Vector3Helper.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/Vector3Helper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    internal class Vector3Helper
+    {
+        public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
+        {
+            Vector3 result;
+            result.x = vector1.y * vector2.z - vector2.y * vector1.z;
+            result.y = vector2.x * vector1.z - vector1.x * vector2.z;
+            result.z = vector1.x * vector2.y - vector2.x * vector1.y;
+            return result;
+        }
+
+        public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
+        {
+            result.x = vector1.y * vector2.z - vector2.y * vector1.z;
+            result.y = vector2.x * vector1.z - vector1.x * vector2.z;
+            result.z = vector1.x * vector2.y - vector2.x * vector1.y;
+        }
+
+        public static float Dot(Vector3 vector1, Vector3 vector2)
+        {
+            return vector1.x * vector2.x + vector1.y * vector2.y + vector1.z * vector2.z;
+        }
+
+        public static Vector3 Normalize(ref Vector3 value)
+        {
+            float factor = 1f / (float)Math.Sqrt((double)(value.x * value.x + value.y * value.y + value.z * value.z));
+            value.x *= factor;
+            value.y *= factor;
+            value.z *= factor;
+            return value;
+        }
+
+        public static void Normalize(ref Vector3 value, out Vector3 result)
+        {
+            float factor = 1f / (float)Math.Sqrt((double)(value.x * value.x + value.y * value.y + value.z * value.z));
+            result.x = value.x * factor;
+            result.y = value.y * factor;
+            result.z = value.z * factor;
+        }
+
+        public static Vector3 Transform(ref Vector3 position, Matrix matrix)
+        {
+            Transform(ref position, ref matrix, out position);
+            return position;
+        }
+
+        public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
+        {
+            result = new Vector3((position.x * matrix.M11) + (position.y * matrix.M21) + (position.z * matrix.M31) + matrix.M41,
+                                 (position.x * matrix.M12) + (position.y * matrix.M22) + (position.z * matrix.M32) + matrix.M42,
+                                 (position.x * matrix.M13) + (position.y * matrix.M23) + (position.z * matrix.M33) + matrix.M43);
+        }
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/Vector3Helper.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/HelperCode/Vector3Helper.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 92533a585fab80e42b8525d114a8c632
+timeCreated: 1429901520
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Microsoft.Xna/Matrix.cs
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Matrix.cs
@@ -1,0 +1,1529 @@
+﻿#region License
+/*
+MIT License
+Copyright © 2006 The Mono.Xna Team
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion License
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.Xna.Framework
+{
+    public struct Matrix : IEquatable<Matrix>
+    {
+        #region Public Fields
+
+        public float M11;
+        public float M12;
+        public float M13;
+        public float M14;
+        public float M21;
+        public float M22;
+        public float M23;
+        public float M24;
+        public float M31;
+        public float M32;
+        public float M33;
+        public float M34;
+        public float M41;
+        public float M42;
+        public float M43;
+        public float M44;
+
+        #endregion Public Fields
+
+
+        #region Static Properties
+
+        private static Matrix identity = new Matrix(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f);
+        public static Matrix Identity
+        {
+            get { return identity; }
+        }
+
+        #endregion Static Properties
+
+
+        #region Public Properties
+
+        public Vector3 Backward
+        {
+            get { return new Vector3(this.M31, this.M32, this.M33); }
+            set
+            {
+                this.M31 = value.x;
+                this.M32 = value.y;
+                this.M33 = value.z;
+            }
+        }
+
+        public Vector3 Down
+        {
+            get { return new Vector3(-this.M21, -this.M22, -this.M23); }
+            set
+            {
+                this.M21 = -value.x;
+                this.M22 = -value.y;
+                this.M23 = -value.z;
+            }
+        }
+
+        public Vector3 Forward
+        {
+            get { return new Vector3(-this.M31, -this.M32, -this.M33); }
+            set
+            {
+                this.M31 = -value.x;
+                this.M32 = -value.y;
+                this.M33 = -value.z;
+            }
+        }
+
+        public Vector3 Left
+        {
+            get { return new Vector3(-this.M11, -this.M12, -this.M13); }
+            set
+            {
+                this.M11 = -value.x;
+                this.M12 = -value.y;
+                this.M13 = -value.z;
+            }
+        }
+
+        public Vector3 Right
+        {
+            get { return new Vector3(this.M11, this.M12, this.M13); }
+            set
+            {
+                this.M11 = value.x;
+                this.M12 = value.y;
+                this.M13 = value.z;
+            }
+        }
+
+        public Vector3 Translation
+        {
+            get { return new Vector3(this.M41, this.M42, this.M43); }
+            set
+            {
+                this.M41 = value.x;
+                this.M42 = value.y;
+                this.M43 = value.z;
+            }
+        }
+
+        public Vector3 Up
+        {
+            get { return new Vector3(this.M21, this.M22, this.M23); }
+            set
+            {
+                this.M21 = value.x;
+                this.M22 = value.y;
+                this.M23 = value.z;
+            }
+        }
+
+        #endregion Public Properties
+
+
+        #region Constructors
+        /// <summary>
+        /// Constructor for 4x4 Matrix
+        /// </summary>
+        /// <param name="m11">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m12">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m13">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m14">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m21">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m22">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m23">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m24">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m31">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m32">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m33">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m34">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m41">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m42">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m43">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        /// <param name="m44">
+        /// A <see cref="System.Single"/>
+        /// </param>
+        public Matrix(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24,
+                              float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44)
+        {
+            this.M11 = m11;
+            this.M12 = m12;
+            this.M13 = m13;
+            this.M14 = m14;
+            this.M21 = m21;
+            this.M22 = m22;
+            this.M23 = m23;
+            this.M24 = m24;
+            this.M31 = m31;
+            this.M32 = m32;
+            this.M33 = m33;
+            this.M34 = m34;
+            this.M41 = m41;
+            this.M42 = m42;
+            this.M43 = m43;
+            this.M44 = m44;
+        }
+
+        #endregion Constructors
+
+        #region Public Static Methods
+
+        public static Matrix CreateWorld(Vector3 position, Vector3 forward, Vector3 up)
+        {
+            Matrix ret;
+            CreateWorld(ref position, ref forward, ref up, out ret);
+            return ret;
+        }
+
+        public static void CreateWorld(ref Vector3 position, ref Vector3 forward, ref Vector3 up, out Matrix result)
+        {
+            Vector3 x, y, z;
+            Vector3Helper.Normalize(ref forward, out z);
+            Vector3Helper.Cross(ref forward, ref up, out x);
+            Vector3Helper.Cross(ref x, ref forward, out y);
+            x.Normalize();
+            y.Normalize();
+
+            result = new Matrix();
+            result.Right = x;
+            result.Up = y;
+            result.Forward = z;
+            result.Translation = position;
+            result.M44 = 1f;
+        }
+
+        public static Matrix CreateShadow(Vector3 lightDirection, Plane plane)
+        {
+            Matrix ret;
+            CreateShadow(ref lightDirection, ref plane, out ret);
+            return ret;
+        }
+
+        public static void CreateShadow(ref Vector3 lightDirection, ref Plane plane, out Matrix result)
+        {
+            // Formula:
+            // http://msdn.microsoft.com/en-us/library/bb205364(v=VS.85).aspx
+
+            Plane p = PlaneHelper.Normalize(plane);
+            float d = Vector3.Dot(p.normal, lightDirection);
+
+            result.M11 = -1 * p.normal.x * lightDirection.x + d;
+            result.M12 = -1 * p.normal.x * lightDirection.y;
+            result.M13 = -1 * p.normal.x * lightDirection.z;
+            result.M14 = 0;
+            result.M21 = -1 * p.normal.y * lightDirection.x;
+            result.M22 = -1 * p.normal.y * lightDirection.y + d;
+            result.M23 = -1 * p.normal.y * lightDirection.z;
+            result.M24 = 0;
+            result.M31 = -1 * p.normal.z * lightDirection.x;
+            result.M32 = -1 * p.normal.z * lightDirection.y;
+            result.M33 = -1 * p.normal.z * lightDirection.z + d;
+            result.M34 = 0;
+            result.M41 = -1 * p.distance * lightDirection.x;
+            result.M42 = -1 * p.distance * lightDirection.y;
+            result.M43 = -1 * p.distance * lightDirection.z;
+            result.M44 = d;
+        }
+
+        public static void CreateReflection(ref Plane value, out Matrix result)
+        {
+            // Formula:
+            // http://msdn.microsoft.com/en-us/library/bb205356(v=VS.85).aspx
+
+            Plane p = PlaneHelper.Normalize(value);
+
+            result.M11 = -2 * p.normal.x * p.normal.x + 1;
+            result.M12 = -2 * p.normal.x * p.normal.y;
+            result.M13 = -2 * p.normal.x * p.normal.z;
+            result.M14 = 0;
+            result.M21 = -2 * p.normal.y * p.normal.x;
+            result.M22 = -2 * p.normal.y * p.normal.y + 1;
+            result.M23 = -2 * p.normal.y * p.normal.z;
+            result.M24 = 0;
+            result.M31 = -2 * p.normal.z * p.normal.x;
+            result.M32 = -2 * p.normal.z * p.normal.y;
+            result.M33 = -2 * p.normal.z * p.normal.z + 1;
+            result.M34 = 0;
+            result.M41 = -2 * p.distance * p.normal.x;
+            result.M42 = -2 * p.distance * p.normal.y;
+            result.M43 = -2 * p.distance * p.normal.z;
+            result.M44 = 1;
+        }
+
+        public static Matrix CreateReflection(Plane value)
+        {
+            Matrix ret;
+            CreateReflection(ref value, out ret);
+            return ret;
+        }
+
+        public static Matrix CreateFromYawPitchRoll(float yaw, float pitch, float roll)
+        {
+            Matrix matrix;
+            Quaternion quaternion = QuaternionHelper.CreateFromYawPitchRoll(yaw, pitch, roll);
+            
+            CreateFromQuaternion(ref quaternion, out matrix);
+            return matrix;
+        }
+
+        public static void CreateFromYawPitchRoll(float yaw, float pitch, float roll, out Matrix result)
+        {
+            Quaternion quaternion = QuaternionHelper.CreateFromYawPitchRoll(yaw, pitch, roll);
+            CreateFromQuaternion(ref quaternion, out result);
+        }
+
+        public static void Transform(ref Matrix value, ref Quaternion rotation, out Matrix result)
+        {
+            Matrix matrix = CreateFromQuaternion(rotation);
+            Matrix.Multiply(ref value, ref matrix, out result);
+        }
+
+        public static Matrix Transform(Matrix value, Quaternion rotation)
+        {
+            Matrix ret;
+            Transform(ref value, ref rotation, out ret);
+            return ret;
+        }
+
+        public bool Decompose(out Vector3 scale, out Quaternion rotation, out Vector3 translation)
+        {
+            translation.x = this.M41;
+            translation.y = this.M42;
+            translation.z = this.M43;
+            float xs, ys, zs;
+
+            if (Math.Sign(M11 * M12 * M13 * M14) < 0)
+                xs = -1f;
+            else
+                xs = 1f;
+
+            if (Math.Sign(M21 * M22 * M23 * M24) < 0)
+                ys = -1f;
+            else
+                ys = 1f;
+
+            if (Math.Sign(M31 * M32 * M33 * M34) < 0)
+                zs = -1f;
+            else
+                zs = 1f;
+
+            scale.x = xs * (float)Math.Sqrt(this.M11 * this.M11 + this.M12 * this.M12 + this.M13 * this.M13);
+            scale.y = ys * (float)Math.Sqrt(this.M21 * this.M21 + this.M22 * this.M22 + this.M23 * this.M23);
+            scale.z = zs * (float)Math.Sqrt(this.M31 * this.M31 + this.M32 * this.M32 + this.M33 * this.M33);
+
+            if (scale.x == 0.0 || scale.y == 0.0 || scale.z == 0.0)
+            {
+                rotation = Quaternion.identity;
+                return false;
+            }
+
+            Matrix m1 = new Matrix(this.M11 / scale.x, M12 / scale.x, M13 / scale.x, 0,
+                    this.M21 / scale.y, M22 / scale.y, M23 / scale.y, 0,
+                    this.M31 / scale.z, M32 / scale.z, M33 / scale.z, 0,
+                    0, 0, 0, 1);
+
+            rotation = QuaternionHelper.CreateFromRotationMatrix(m1);
+            return true;
+        }
+
+        /// <summary>
+        /// Adds second matrix to the first.
+        /// </summary>
+        /// <param name="matrix1">
+        /// A <see cref="Matrix"/>
+        /// </param>
+        /// <param name="matrix2">
+        /// A <see cref="Matrix"/>
+        /// </param>
+        /// <returns>
+        /// A <see cref="Matrix"/>
+        /// </returns>
+        public static Matrix Add(Matrix matrix1, Matrix matrix2)
+        {
+            matrix1.M11 += matrix2.M11;
+            matrix1.M12 += matrix2.M12;
+            matrix1.M13 += matrix2.M13;
+            matrix1.M14 += matrix2.M14;
+            matrix1.M21 += matrix2.M21;
+            matrix1.M22 += matrix2.M22;
+            matrix1.M23 += matrix2.M23;
+            matrix1.M24 += matrix2.M24;
+            matrix1.M31 += matrix2.M31;
+            matrix1.M32 += matrix2.M32;
+            matrix1.M33 += matrix2.M33;
+            matrix1.M34 += matrix2.M34;
+            matrix1.M41 += matrix2.M41;
+            matrix1.M42 += matrix2.M42;
+            matrix1.M43 += matrix2.M43;
+            matrix1.M44 += matrix2.M44;
+            return matrix1;
+        }
+
+
+        /// <summary>
+        /// Adds two Matrix and save to the result Matrix
+        /// </summary>
+        /// <param name="matrix1">
+        /// A <see cref="Matrix"/>
+        /// </param>
+        /// <param name="matrix2">
+        /// A <see cref="Matrix"/>
+        /// </param>
+        /// <param name="result">
+        /// A <see cref="Matrix"/>
+        /// </param>
+        public static void Add(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
+        {
+            result.M11 = matrix1.M11 + matrix2.M11;
+            result.M12 = matrix1.M12 + matrix2.M12;
+            result.M13 = matrix1.M13 + matrix2.M13;
+            result.M14 = matrix1.M14 + matrix2.M14;
+            result.M21 = matrix1.M21 + matrix2.M21;
+            result.M22 = matrix1.M22 + matrix2.M22;
+            result.M23 = matrix1.M23 + matrix2.M23;
+            result.M24 = matrix1.M24 + matrix2.M24;
+            result.M31 = matrix1.M31 + matrix2.M31;
+            result.M32 = matrix1.M32 + matrix2.M32;
+            result.M33 = matrix1.M33 + matrix2.M33;
+            result.M34 = matrix1.M34 + matrix2.M34;
+            result.M41 = matrix1.M41 + matrix2.M41;
+            result.M42 = matrix1.M42 + matrix2.M42;
+            result.M43 = matrix1.M43 + matrix2.M43;
+            result.M44 = matrix1.M44 + matrix2.M44;
+        }
+
+
+        public static Matrix CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition,
+            Vector3 cameraUpVector, Nullable<Vector3> cameraForwardVector)
+        {
+            Matrix ret;
+            CreateBillboard(ref objectPosition, ref cameraPosition, ref cameraUpVector, cameraForwardVector, out ret);
+            return ret;
+        }
+
+        public static void CreateBillboard(ref Vector3 objectPosition, ref Vector3 cameraPosition,
+            ref Vector3 cameraUpVector, Vector3? cameraForwardVector, out Matrix result)
+        {
+            Vector3 translation = objectPosition - cameraPosition;
+            Vector3 backwards = translation.normalized;
+            Vector3 right = Vector3.right;
+            Vector3 up = cameraUpVector.normalized;
+            //Vector3.Normalize(ref translation, out backwards);
+            //Vector3.Normalize(ref cameraUpVector, out up);
+            //Vector3.Cross(ref backwards, ref up, out right);
+            //Vector3.Cross(ref backwards, ref right, out up);
+            right = Vector3.Cross(backwards, right);
+            up = Vector3.Cross(backwards, up);
+            result = Matrix.Identity;
+            result.Backward = backwards;
+            result.Right = right;
+            result.Up = up;
+            result.Translation = translation;
+        }
+
+        public static Matrix CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition,
+            Vector3 rotateAxis, Nullable<Vector3> cameraForwardVector, Nullable<Vector3> objectForwardVector)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static void CreateConstrainedBillboard(ref Vector3 objectPosition, ref Vector3 cameraPosition,
+            ref Vector3 rotateAxis, Vector3? cameraForwardVector, Vector3? objectForwardVector, out Matrix result)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static Matrix CreateFromAxisAngle(Vector3 axis, float angle)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static void CreateFromAxisAngle(ref Vector3 axis, float angle, out Matrix result)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static Matrix CreateFromQuaternion(Quaternion quaternion)
+        {
+            Matrix ret;
+            CreateFromQuaternion(ref quaternion, out ret);
+            return ret;
+        }
+
+
+        public static void CreateFromQuaternion(ref Quaternion quaternion, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = 1 - 2 * (quaternion.y * quaternion.y + quaternion.z * quaternion.z);
+            result.M12 = 2 * (quaternion.x * quaternion.y + quaternion.w * quaternion.z);
+            result.M13 = 2 * (quaternion.x * quaternion.z - quaternion.w * quaternion.y);
+            result.M21 = 2 * (quaternion.x * quaternion.y - quaternion.w * quaternion.z);
+            result.M22 = 1 - 2 * (quaternion.x * quaternion.x + quaternion.z * quaternion.z);
+            result.M23 = 2 * (quaternion.y * quaternion.z + quaternion.w * quaternion.x);
+            result.M31 = 2 * (quaternion.x * quaternion.z + quaternion.w * quaternion.y);
+            result.M32 = 2 * (quaternion.y * quaternion.z - quaternion.w * quaternion.x);
+            result.M33 = 1 - 2 * (quaternion.x * quaternion.x + quaternion.y * quaternion.y);
+        }
+
+
+        public static Matrix CreateLookAt(Vector3 cameraPosition, Vector3 cameraTarget, Vector3 cameraUpVector)
+        {
+            Matrix ret;
+            CreateLookAt(ref cameraPosition, ref cameraTarget, ref cameraUpVector, out ret);
+            return ret;
+        }
+
+
+        public static void CreateLookAt(ref Vector3 cameraPosition, ref Vector3 cameraTarget, ref Vector3 cameraUpVector, out Matrix result)
+        {
+            // http://msdn.microsoft.com/en-us/library/bb205343(v=VS.85).aspx
+
+            Vector3 vz = Vector3.Normalize(cameraPosition - cameraTarget);
+            Vector3 vx = Vector3.Normalize(Vector3.Cross(cameraUpVector, vz));
+            Vector3 vy = Vector3.Cross(vz, vx);
+            result = Matrix.Identity;
+            result.M11 = vx.x;
+            result.M12 = vy.x;
+            result.M13 = vz.x;
+            result.M21 = vx.y;
+            result.M22 = vy.y;
+            result.M23 = vz.y;
+            result.M31 = vx.z;
+            result.M32 = vy.z;
+            result.M33 = vz.z;
+            result.M41 = -Vector3.Dot(vx, cameraPosition);
+            result.M42 = -Vector3.Dot(vy, cameraPosition);
+            result.M43 = -Vector3.Dot(vz, cameraPosition);
+        }
+
+        public static Matrix CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane)
+        {
+            Matrix ret;
+            CreateOrthographic(width, height, zNearPlane, zFarPlane, out ret);
+            return ret;
+        }
+
+
+        public static void CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane, out Matrix result)
+        {
+            result.M11 = 2 / width;
+            result.M12 = 0;
+            result.M13 = 0;
+            result.M14 = 0;
+            result.M21 = 0;
+            result.M22 = 2 / height;
+            result.M23 = 0;
+            result.M24 = 0;
+            result.M31 = 0;
+            result.M32 = 0;
+            result.M33 = 1 / (zNearPlane - zFarPlane);
+            result.M34 = 0;
+            result.M41 = 0;
+            result.M42 = 0;
+            result.M43 = zNearPlane / (zNearPlane - zFarPlane);
+            result.M44 = 1;
+        }
+
+
+        public static Matrix CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
+        {
+            Matrix ret;
+            CreateOrthographicOffCenter(left, right, bottom, top, zNearPlane, zFarPlane, out ret);
+            return ret;
+        }
+
+
+        public static void CreateOrthographicOffCenter(float left, float right, float bottom, float top,
+            float zNearPlane, float zFarPlane, out Matrix result)
+        {
+            result.M11 = 2 / (right - left);
+            result.M12 = 0;
+            result.M13 = 0;
+            result.M14 = 0;
+            result.M21 = 0;
+            result.M22 = 2 / (top - bottom);
+            result.M23 = 0;
+            result.M24 = 0;
+            result.M31 = 0;
+            result.M32 = 0;
+            result.M33 = 1 / (zNearPlane - zFarPlane);
+            result.M34 = 0;
+            result.M41 = (left + right) / (left - right);
+            result.M42 = (bottom + top) / (bottom - top);
+            result.M43 = zNearPlane / (zNearPlane - zFarPlane);
+            result.M44 = 1;
+        }
+
+
+        public static Matrix CreatePerspective(float width, float height, float zNearPlane, float zFarPlane)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static void CreatePerspective(float width, float height, float zNearPlane, float zFarPlane, out Matrix result)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static Matrix CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance)
+        {
+            Matrix ret;
+            CreatePerspectiveFieldOfView(fieldOfView, aspectRatio, nearPlaneDistance, farPlaneDistance, out ret);
+            return ret;
+        }
+
+
+        public static void CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance, out Matrix result)
+        {
+            // http://msdn.microsoft.com/en-us/library/bb205351(v=VS.85).aspx
+            // http://msdn.microsoft.com/en-us/library/bb195665.aspx
+
+            result = new Matrix(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+            if (fieldOfView < 0 || fieldOfView > 3.14159262f)
+                throw new ArgumentOutOfRangeException("fieldOfView", "fieldOfView takes a value between 0 and Pi (180 degrees) in radians.");
+
+            if (nearPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException("nearPlaneDistance", "You should specify positive value for nearPlaneDistance.");
+
+            if (farPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException("farPlaneDistance", "You should specify positive value for farPlaneDistance.");
+
+            if (farPlaneDistance <= nearPlaneDistance)
+                throw new ArgumentOutOfRangeException("nearPlaneDistance", "Near plane distance is larger than Far plane distance. Near plane distance must be smaller than Far plane distance.");
+
+            float yscale = (float)1 / (float)Math.Tan(fieldOfView / 2);
+            float xscale = yscale / aspectRatio;
+
+            result.M11 = xscale;
+            result.M22 = yscale;
+            result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+            result.M34 = -1;
+            result.M43 = nearPlaneDistance * farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+        }
+
+
+        public static Matrix CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static void CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance, out Matrix result)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static Matrix CreateRotationX(float radians)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M22 = (float)Math.Cos(radians);
+            returnMatrix.M23 = (float)Math.Sin(radians);
+            returnMatrix.M32 = -returnMatrix.M23;
+            returnMatrix.M33 = returnMatrix.M22;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateRotationX(float radians, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M22 = (float)Math.Cos(radians);
+            result.M23 = (float)Math.Sin(radians);
+            result.M32 = -result.M23;
+            result.M33 = result.M22;
+        }
+
+
+        public static Matrix CreateRotationY(float radians)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M11 = (float)Math.Cos(radians);
+            returnMatrix.M13 = (float)Math.Sin(radians);
+            returnMatrix.M31 = -returnMatrix.M13;
+            returnMatrix.M33 = returnMatrix.M11;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateRotationY(float radians, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = (float)Math.Cos(radians);
+            result.M13 = (float)Math.Sin(radians);
+            result.M31 = -result.M13;
+            result.M33 = result.M11;
+        }
+
+
+        public static Matrix CreateRotationZ(float radians)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M11 = (float)Math.Cos(radians);
+            returnMatrix.M12 = (float)Math.Sin(radians);
+            returnMatrix.M21 = -returnMatrix.M12;
+            returnMatrix.M22 = returnMatrix.M11;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateRotationZ(float radians, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = (float)Math.Cos(radians);
+            result.M12 = (float)Math.Sin(radians);
+            result.M21 = -result.M12;
+            result.M22 = result.M11;
+        }
+
+
+        public static Matrix CreateScale(float scale)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M11 = scale;
+            returnMatrix.M22 = scale;
+            returnMatrix.M33 = scale;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateScale(float scale, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = scale;
+            result.M22 = scale;
+            result.M33 = scale;
+        }
+
+
+        public static Matrix CreateScale(float xScale, float yScale, float zScale)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M11 = xScale;
+            returnMatrix.M22 = yScale;
+            returnMatrix.M33 = zScale;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateScale(float xScale, float yScale, float zScale, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = xScale;
+            result.M22 = yScale;
+            result.M33 = zScale;
+        }
+
+
+        public static Matrix CreateScale(Vector3 scales)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M11 = scales.x;
+            returnMatrix.M22 = scales.y;
+            returnMatrix.M33 = scales.z;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateScale(ref Vector3 scales, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M11 = scales.x;
+            result.M22 = scales.y;
+            result.M33 = scales.z;
+        }
+
+
+        public static Matrix CreateTranslation(float xPosition, float yPosition, float zPosition)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M41 = xPosition;
+            returnMatrix.M42 = yPosition;
+            returnMatrix.M43 = zPosition;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateTranslation(float xPosition, float yPosition, float zPosition, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M41 = xPosition;
+            result.M42 = yPosition;
+            result.M43 = zPosition;
+        }
+
+
+        public static Matrix CreateTranslation(Vector3 position)
+        {
+            Matrix returnMatrix = Matrix.Identity;
+
+            returnMatrix.M41 = position.x;
+            returnMatrix.M42 = position.y;
+            returnMatrix.M43 = position.z;
+
+            return returnMatrix;
+        }
+
+
+        public static void CreateTranslation(ref Vector3 position, out Matrix result)
+        {
+            result = Matrix.Identity;
+
+            result.M41 = position.x;
+            result.M42 = position.y;
+            result.M43 = position.z;
+        }
+
+        public static Matrix Divide(Matrix matrix1, Matrix matrix2)
+        {
+            Matrix inverse = Matrix.Invert(matrix2), result;
+
+            result.M11 = matrix1.M11 * inverse.M11 + matrix1.M12 * inverse.M21 + matrix1.M13 * inverse.M31 + matrix1.M14 * inverse.M41;
+            result.M12 = matrix1.M11 * inverse.M12 + matrix1.M12 * inverse.M22 + matrix1.M13 * inverse.M32 + matrix1.M14 * inverse.M42;
+            result.M13 = matrix1.M11 * inverse.M13 + matrix1.M12 * inverse.M23 + matrix1.M13 * inverse.M33 + matrix1.M14 * inverse.M43;
+            result.M14 = matrix1.M11 * inverse.M14 + matrix1.M12 * inverse.M24 + matrix1.M13 * inverse.M34 + matrix1.M14 * inverse.M44;
+
+            result.M21 = matrix1.M21 * inverse.M11 + matrix1.M22 * inverse.M21 + matrix1.M23 * inverse.M31 + matrix1.M24 * inverse.M41;
+            result.M22 = matrix1.M21 * inverse.M12 + matrix1.M22 * inverse.M22 + matrix1.M23 * inverse.M32 + matrix1.M24 * inverse.M42;
+            result.M23 = matrix1.M21 * inverse.M13 + matrix1.M22 * inverse.M23 + matrix1.M23 * inverse.M33 + matrix1.M24 * inverse.M43;
+            result.M24 = matrix1.M21 * inverse.M14 + matrix1.M22 * inverse.M24 + matrix1.M23 * inverse.M34 + matrix1.M24 * inverse.M44;
+
+            result.M31 = matrix1.M31 * inverse.M11 + matrix1.M32 * inverse.M21 + matrix1.M33 * inverse.M31 + matrix1.M34 * inverse.M41;
+            result.M32 = matrix1.M31 * inverse.M12 + matrix1.M32 * inverse.M22 + matrix1.M33 * inverse.M32 + matrix1.M34 * inverse.M42;
+            result.M33 = matrix1.M31 * inverse.M13 + matrix1.M32 * inverse.M23 + matrix1.M33 * inverse.M33 + matrix1.M34 * inverse.M43;
+            result.M34 = matrix1.M31 * inverse.M14 + matrix1.M32 * inverse.M24 + matrix1.M33 * inverse.M34 + matrix1.M34 * inverse.M44;
+
+            result.M41 = matrix1.M41 * inverse.M11 + matrix1.M42 * inverse.M21 + matrix1.M43 * inverse.M31 + matrix1.M44 * inverse.M41;
+            result.M42 = matrix1.M41 * inverse.M12 + matrix1.M42 * inverse.M22 + matrix1.M43 * inverse.M32 + matrix1.M44 * inverse.M42;
+            result.M43 = matrix1.M41 * inverse.M13 + matrix1.M42 * inverse.M23 + matrix1.M43 * inverse.M33 + matrix1.M44 * inverse.M43;
+            result.M44 = matrix1.M41 * inverse.M14 + matrix1.M42 * inverse.M24 + matrix1.M43 * inverse.M34 + matrix1.M44 * inverse.M44;
+
+            return result;
+        }
+
+
+        public static void Divide(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
+        {
+            Matrix inverse = Matrix.Invert(matrix2);
+            result.M11 = matrix1.M11 * inverse.M11 + matrix1.M12 * inverse.M21 + matrix1.M13 * inverse.M31 + matrix1.M14 * inverse.M41;
+            result.M12 = matrix1.M11 * inverse.M12 + matrix1.M12 * inverse.M22 + matrix1.M13 * inverse.M32 + matrix1.M14 * inverse.M42;
+            result.M13 = matrix1.M11 * inverse.M13 + matrix1.M12 * inverse.M23 + matrix1.M13 * inverse.M33 + matrix1.M14 * inverse.M43;
+            result.M14 = matrix1.M11 * inverse.M14 + matrix1.M12 * inverse.M24 + matrix1.M13 * inverse.M34 + matrix1.M14 * inverse.M44;
+
+            result.M21 = matrix1.M21 * inverse.M11 + matrix1.M22 * inverse.M21 + matrix1.M23 * inverse.M31 + matrix1.M24 * inverse.M41;
+            result.M22 = matrix1.M21 * inverse.M12 + matrix1.M22 * inverse.M22 + matrix1.M23 * inverse.M32 + matrix1.M24 * inverse.M42;
+            result.M23 = matrix1.M21 * inverse.M13 + matrix1.M22 * inverse.M23 + matrix1.M23 * inverse.M33 + matrix1.M24 * inverse.M43;
+            result.M24 = matrix1.M21 * inverse.M14 + matrix1.M22 * inverse.M24 + matrix1.M23 * inverse.M34 + matrix1.M24 * inverse.M44;
+
+            result.M31 = matrix1.M31 * inverse.M11 + matrix1.M32 * inverse.M21 + matrix1.M33 * inverse.M31 + matrix1.M34 * inverse.M41;
+            result.M32 = matrix1.M31 * inverse.M12 + matrix1.M32 * inverse.M22 + matrix1.M33 * inverse.M32 + matrix1.M34 * inverse.M42;
+            result.M33 = matrix1.M31 * inverse.M13 + matrix1.M32 * inverse.M23 + matrix1.M33 * inverse.M33 + matrix1.M34 * inverse.M43;
+            result.M34 = matrix1.M31 * inverse.M14 + matrix1.M32 * inverse.M24 + matrix1.M33 * inverse.M34 + matrix1.M34 * inverse.M44;
+
+            result.M41 = matrix1.M41 * inverse.M11 + matrix1.M42 * inverse.M21 + matrix1.M43 * inverse.M31 + matrix1.M44 * inverse.M41;
+            result.M42 = matrix1.M41 * inverse.M12 + matrix1.M42 * inverse.M22 + matrix1.M43 * inverse.M32 + matrix1.M44 * inverse.M42;
+            result.M43 = matrix1.M41 * inverse.M13 + matrix1.M42 * inverse.M23 + matrix1.M43 * inverse.M33 + matrix1.M44 * inverse.M43;
+            result.M44 = matrix1.M41 * inverse.M14 + matrix1.M42 * inverse.M24 + matrix1.M43 * inverse.M34 + matrix1.M44 * inverse.M44;
+        }
+
+
+        public static Matrix Divide(Matrix matrix1, float divider)
+        {
+            float inverseDivider = 1.0f / divider;
+
+            matrix1.M11 = matrix1.M11 * inverseDivider;
+            matrix1.M12 = matrix1.M12 * inverseDivider;
+            matrix1.M13 = matrix1.M13 * inverseDivider;
+            matrix1.M14 = matrix1.M14 * inverseDivider;
+            matrix1.M21 = matrix1.M21 * inverseDivider;
+            matrix1.M22 = matrix1.M22 * inverseDivider;
+            matrix1.M23 = matrix1.M23 * inverseDivider;
+            matrix1.M24 = matrix1.M24 * inverseDivider;
+            matrix1.M31 = matrix1.M31 * inverseDivider;
+            matrix1.M32 = matrix1.M32 * inverseDivider;
+            matrix1.M33 = matrix1.M33 * inverseDivider;
+            matrix1.M34 = matrix1.M34 * inverseDivider;
+            matrix1.M41 = matrix1.M41 * inverseDivider;
+            matrix1.M42 = matrix1.M42 * inverseDivider;
+            matrix1.M43 = matrix1.M43 * inverseDivider;
+            matrix1.M44 = matrix1.M44 * inverseDivider;
+
+            return matrix1;
+        }
+
+
+        public static void Divide(ref Matrix matrix1, float divider, out Matrix result)
+        {
+            float inverseDivider = 1.0f / divider;
+            result.M11 = matrix1.M11 * inverseDivider;
+            result.M12 = matrix1.M12 * inverseDivider;
+            result.M13 = matrix1.M13 * inverseDivider;
+            result.M14 = matrix1.M14 * inverseDivider;
+            result.M21 = matrix1.M21 * inverseDivider;
+            result.M22 = matrix1.M22 * inverseDivider;
+            result.M23 = matrix1.M23 * inverseDivider;
+            result.M24 = matrix1.M24 * inverseDivider;
+            result.M31 = matrix1.M31 * inverseDivider;
+            result.M32 = matrix1.M32 * inverseDivider;
+            result.M33 = matrix1.M33 * inverseDivider;
+            result.M34 = matrix1.M34 * inverseDivider;
+            result.M41 = matrix1.M41 * inverseDivider;
+            result.M42 = matrix1.M42 * inverseDivider;
+            result.M43 = matrix1.M43 * inverseDivider;
+            result.M44 = matrix1.M44 * inverseDivider;
+        }
+
+        public static Matrix Invert(Matrix matrix)
+        {
+            Invert(ref matrix, out matrix);
+            return matrix;
+        }
+
+
+        public static void Invert(ref Matrix matrix, out Matrix result)
+        {
+            //
+            // Use Laplace expansion theorem to calculate the inverse of a 4x4 matrix
+            // 
+            // 1. Calculate the 2x2 determinants needed and the 4x4 determinant based on the 2x2 determinants 
+            // 2. Create the adjugate matrix, which satisfies: A * adj(A) = det(A) * I
+            // 3. Divide adjugate matrix with the determinant to find the inverse
+
+            float det1 = matrix.M11 * matrix.M22 - matrix.M12 * matrix.M21;
+            float det2 = matrix.M11 * matrix.M23 - matrix.M13 * matrix.M21;
+            float det3 = matrix.M11 * matrix.M24 - matrix.M14 * matrix.M21;
+            float det4 = matrix.M12 * matrix.M23 - matrix.M13 * matrix.M22;
+            float det5 = matrix.M12 * matrix.M24 - matrix.M14 * matrix.M22;
+            float det6 = matrix.M13 * matrix.M24 - matrix.M14 * matrix.M23;
+            float det7 = matrix.M31 * matrix.M42 - matrix.M32 * matrix.M41;
+            float det8 = matrix.M31 * matrix.M43 - matrix.M33 * matrix.M41;
+            float det9 = matrix.M31 * matrix.M44 - matrix.M34 * matrix.M41;
+            float det10 = matrix.M32 * matrix.M43 - matrix.M33 * matrix.M42;
+            float det11 = matrix.M32 * matrix.M44 - matrix.M34 * matrix.M42;
+            float det12 = matrix.M33 * matrix.M44 - matrix.M34 * matrix.M43;
+
+            float detMatrix = (float)(det1 * det12 - det2 * det11 + det3 * det10 + det4 * det9 - det5 * det8 + det6 * det7);
+
+            float invDetMatrix = 1f / detMatrix;
+
+            Matrix ret; // Allow for matrix and result to point to the same structure
+
+            ret.M11 = (matrix.M22 * det12 - matrix.M23 * det11 + matrix.M24 * det10) * invDetMatrix;
+            ret.M12 = (-matrix.M12 * det12 + matrix.M13 * det11 - matrix.M14 * det10) * invDetMatrix;
+            ret.M13 = (matrix.M42 * det6 - matrix.M43 * det5 + matrix.M44 * det4) * invDetMatrix;
+            ret.M14 = (-matrix.M32 * det6 + matrix.M33 * det5 - matrix.M34 * det4) * invDetMatrix;
+            ret.M21 = (-matrix.M21 * det12 + matrix.M23 * det9 - matrix.M24 * det8) * invDetMatrix;
+            ret.M22 = (matrix.M11 * det12 - matrix.M13 * det9 + matrix.M14 * det8) * invDetMatrix;
+            ret.M23 = (-matrix.M41 * det6 + matrix.M43 * det3 - matrix.M44 * det2) * invDetMatrix;
+            ret.M24 = (matrix.M31 * det6 - matrix.M33 * det3 + matrix.M34 * det2) * invDetMatrix;
+            ret.M31 = (matrix.M21 * det11 - matrix.M22 * det9 + matrix.M24 * det7) * invDetMatrix;
+            ret.M32 = (-matrix.M11 * det11 + matrix.M12 * det9 - matrix.M14 * det7) * invDetMatrix;
+            ret.M33 = (matrix.M41 * det5 - matrix.M42 * det3 + matrix.M44 * det1) * invDetMatrix;
+            ret.M34 = (-matrix.M31 * det5 + matrix.M32 * det3 - matrix.M34 * det1) * invDetMatrix;
+            ret.M41 = (-matrix.M21 * det10 + matrix.M22 * det8 - matrix.M23 * det7) * invDetMatrix;
+            ret.M42 = (matrix.M11 * det10 - matrix.M12 * det8 + matrix.M13 * det7) * invDetMatrix;
+            ret.M43 = (-matrix.M41 * det4 + matrix.M42 * det2 - matrix.M43 * det1) * invDetMatrix;
+            ret.M44 = (matrix.M31 * det4 - matrix.M32 * det2 + matrix.M33 * det1) * invDetMatrix;
+
+            result = ret;
+        }
+
+
+        public static Matrix Lerp(Matrix matrix1, Matrix matrix2, float amount)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public static void Lerp(ref Matrix matrix1, ref Matrix matrix2, float amount, out Matrix result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Matrix Multiply(Matrix matrix1, Matrix matrix2)
+        {
+            Matrix result;
+
+            result.M11 = matrix1.M11 * matrix2.M11 + matrix1.M12 * matrix2.M21 + matrix1.M13 * matrix2.M31 + matrix1.M14 * matrix2.M41;
+            result.M12 = matrix1.M11 * matrix2.M12 + matrix1.M12 * matrix2.M22 + matrix1.M13 * matrix2.M32 + matrix1.M14 * matrix2.M42;
+            result.M13 = matrix1.M11 * matrix2.M13 + matrix1.M12 * matrix2.M23 + matrix1.M13 * matrix2.M33 + matrix1.M14 * matrix2.M43;
+            result.M14 = matrix1.M11 * matrix2.M14 + matrix1.M12 * matrix2.M24 + matrix1.M13 * matrix2.M34 + matrix1.M14 * matrix2.M44;
+
+            result.M21 = matrix1.M21 * matrix2.M11 + matrix1.M22 * matrix2.M21 + matrix1.M23 * matrix2.M31 + matrix1.M24 * matrix2.M41;
+            result.M22 = matrix1.M21 * matrix2.M12 + matrix1.M22 * matrix2.M22 + matrix1.M23 * matrix2.M32 + matrix1.M24 * matrix2.M42;
+            result.M23 = matrix1.M21 * matrix2.M13 + matrix1.M22 * matrix2.M23 + matrix1.M23 * matrix2.M33 + matrix1.M24 * matrix2.M43;
+            result.M24 = matrix1.M21 * matrix2.M14 + matrix1.M22 * matrix2.M24 + matrix1.M23 * matrix2.M34 + matrix1.M24 * matrix2.M44;
+
+            result.M31 = matrix1.M31 * matrix2.M11 + matrix1.M32 * matrix2.M21 + matrix1.M33 * matrix2.M31 + matrix1.M34 * matrix2.M41;
+            result.M32 = matrix1.M31 * matrix2.M12 + matrix1.M32 * matrix2.M22 + matrix1.M33 * matrix2.M32 + matrix1.M34 * matrix2.M42;
+            result.M33 = matrix1.M31 * matrix2.M13 + matrix1.M32 * matrix2.M23 + matrix1.M33 * matrix2.M33 + matrix1.M34 * matrix2.M43;
+            result.M34 = matrix1.M31 * matrix2.M14 + matrix1.M32 * matrix2.M24 + matrix1.M33 * matrix2.M34 + matrix1.M34 * matrix2.M44;
+
+            result.M41 = matrix1.M41 * matrix2.M11 + matrix1.M42 * matrix2.M21 + matrix1.M43 * matrix2.M31 + matrix1.M44 * matrix2.M41;
+            result.M42 = matrix1.M41 * matrix2.M12 + matrix1.M42 * matrix2.M22 + matrix1.M43 * matrix2.M32 + matrix1.M44 * matrix2.M42;
+            result.M43 = matrix1.M41 * matrix2.M13 + matrix1.M42 * matrix2.M23 + matrix1.M43 * matrix2.M33 + matrix1.M44 * matrix2.M43;
+            result.M44 = matrix1.M41 * matrix2.M14 + matrix1.M42 * matrix2.M24 + matrix1.M43 * matrix2.M34 + matrix1.M44 * matrix2.M44;
+
+            return result;
+        }
+
+
+        public static void Multiply(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
+        {
+            result.M11 = matrix1.M11 * matrix2.M11 + matrix1.M12 * matrix2.M21 + matrix1.M13 * matrix2.M31 + matrix1.M14 * matrix2.M41;
+            result.M12 = matrix1.M11 * matrix2.M12 + matrix1.M12 * matrix2.M22 + matrix1.M13 * matrix2.M32 + matrix1.M14 * matrix2.M42;
+            result.M13 = matrix1.M11 * matrix2.M13 + matrix1.M12 * matrix2.M23 + matrix1.M13 * matrix2.M33 + matrix1.M14 * matrix2.M43;
+            result.M14 = matrix1.M11 * matrix2.M14 + matrix1.M12 * matrix2.M24 + matrix1.M13 * matrix2.M34 + matrix1.M14 * matrix2.M44;
+
+            result.M21 = matrix1.M21 * matrix2.M11 + matrix1.M22 * matrix2.M21 + matrix1.M23 * matrix2.M31 + matrix1.M24 * matrix2.M41;
+            result.M22 = matrix1.M21 * matrix2.M12 + matrix1.M22 * matrix2.M22 + matrix1.M23 * matrix2.M32 + matrix1.M24 * matrix2.M42;
+            result.M23 = matrix1.M21 * matrix2.M13 + matrix1.M22 * matrix2.M23 + matrix1.M23 * matrix2.M33 + matrix1.M24 * matrix2.M43;
+            result.M24 = matrix1.M21 * matrix2.M14 + matrix1.M22 * matrix2.M24 + matrix1.M23 * matrix2.M34 + matrix1.M24 * matrix2.M44;
+
+            result.M31 = matrix1.M31 * matrix2.M11 + matrix1.M32 * matrix2.M21 + matrix1.M33 * matrix2.M31 + matrix1.M34 * matrix2.M41;
+            result.M32 = matrix1.M31 * matrix2.M12 + matrix1.M32 * matrix2.M22 + matrix1.M33 * matrix2.M32 + matrix1.M34 * matrix2.M42;
+            result.M33 = matrix1.M31 * matrix2.M13 + matrix1.M32 * matrix2.M23 + matrix1.M33 * matrix2.M33 + matrix1.M34 * matrix2.M43;
+            result.M34 = matrix1.M31 * matrix2.M14 + matrix1.M32 * matrix2.M24 + matrix1.M33 * matrix2.M34 + matrix1.M34 * matrix2.M44;
+
+            result.M41 = matrix1.M41 * matrix2.M11 + matrix1.M42 * matrix2.M21 + matrix1.M43 * matrix2.M31 + matrix1.M44 * matrix2.M41;
+            result.M42 = matrix1.M41 * matrix2.M12 + matrix1.M42 * matrix2.M22 + matrix1.M43 * matrix2.M32 + matrix1.M44 * matrix2.M42;
+            result.M43 = matrix1.M41 * matrix2.M13 + matrix1.M42 * matrix2.M23 + matrix1.M43 * matrix2.M33 + matrix1.M44 * matrix2.M43;
+            result.M44 = matrix1.M41 * matrix2.M14 + matrix1.M42 * matrix2.M24 + matrix1.M43 * matrix2.M34 + matrix1.M44 * matrix2.M44;
+        }
+
+
+        public static Matrix Multiply(Matrix matrix1, float factor)
+        {
+            matrix1.M11 *= factor;
+            matrix1.M12 *= factor;
+            matrix1.M13 *= factor;
+            matrix1.M14 *= factor;
+            matrix1.M21 *= factor;
+            matrix1.M22 *= factor;
+            matrix1.M23 *= factor;
+            matrix1.M24 *= factor;
+            matrix1.M31 *= factor;
+            matrix1.M32 *= factor;
+            matrix1.M33 *= factor;
+            matrix1.M34 *= factor;
+            matrix1.M41 *= factor;
+            matrix1.M42 *= factor;
+            matrix1.M43 *= factor;
+            matrix1.M44 *= factor;
+            return matrix1;
+        }
+
+
+        public static void Multiply(ref Matrix matrix1, float factor, out Matrix result)
+        {
+            result.M11 = matrix1.M11 * factor;
+            result.M12 = matrix1.M12 * factor;
+            result.M13 = matrix1.M13 * factor;
+            result.M14 = matrix1.M14 * factor;
+            result.M21 = matrix1.M21 * factor;
+            result.M22 = matrix1.M22 * factor;
+            result.M23 = matrix1.M23 * factor;
+            result.M24 = matrix1.M24 * factor;
+            result.M31 = matrix1.M31 * factor;
+            result.M32 = matrix1.M32 * factor;
+            result.M33 = matrix1.M33 * factor;
+            result.M34 = matrix1.M34 * factor;
+            result.M41 = matrix1.M41 * factor;
+            result.M42 = matrix1.M42 * factor;
+            result.M43 = matrix1.M43 * factor;
+            result.M44 = matrix1.M44 * factor;
+        }
+
+
+        public static Matrix Negate(Matrix matrix)
+        {
+            matrix.M11 = -matrix.M11;
+            matrix.M12 = -matrix.M12;
+            matrix.M13 = -matrix.M13;
+            matrix.M14 = -matrix.M14;
+            matrix.M21 = -matrix.M21;
+            matrix.M22 = -matrix.M22;
+            matrix.M23 = -matrix.M23;
+            matrix.M24 = -matrix.M24;
+            matrix.M31 = -matrix.M31;
+            matrix.M32 = -matrix.M32;
+            matrix.M33 = -matrix.M33;
+            matrix.M34 = -matrix.M34;
+            matrix.M41 = -matrix.M41;
+            matrix.M42 = -matrix.M42;
+            matrix.M43 = -matrix.M43;
+            matrix.M44 = -matrix.M44;
+            return matrix;
+        }
+
+
+        public static void Negate(ref Matrix matrix, out Matrix result)
+        {
+            result.M11 = matrix.M11;
+            result.M12 = matrix.M12;
+            result.M13 = matrix.M13;
+            result.M14 = matrix.M14;
+            result.M21 = matrix.M21;
+            result.M22 = matrix.M22;
+            result.M23 = matrix.M23;
+            result.M24 = matrix.M24;
+            result.M31 = matrix.M31;
+            result.M32 = matrix.M32;
+            result.M33 = matrix.M33;
+            result.M34 = matrix.M34;
+            result.M41 = matrix.M41;
+            result.M42 = matrix.M42;
+            result.M43 = matrix.M43;
+            result.M44 = matrix.M44;
+        }
+
+        public static Matrix Subtract(Matrix matrix1, Matrix matrix2)
+        {
+            matrix1.M11 -= matrix2.M11;
+            matrix1.M12 -= matrix2.M12;
+            matrix1.M13 -= matrix2.M13;
+            matrix1.M14 -= matrix2.M14;
+            matrix1.M21 -= matrix2.M21;
+            matrix1.M22 -= matrix2.M22;
+            matrix1.M23 -= matrix2.M23;
+            matrix1.M24 -= matrix2.M24;
+            matrix1.M31 -= matrix2.M31;
+            matrix1.M32 -= matrix2.M32;
+            matrix1.M33 -= matrix2.M33;
+            matrix1.M34 -= matrix2.M34;
+            matrix1.M41 -= matrix2.M41;
+            matrix1.M42 -= matrix2.M42;
+            matrix1.M43 -= matrix2.M43;
+            matrix1.M44 -= matrix2.M44;
+            return matrix1;
+        }
+
+        public static void Subtract(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
+        {
+            result.M11 = matrix1.M11 - matrix2.M11;
+            result.M12 = matrix1.M12 - matrix2.M12;
+            result.M13 = matrix1.M13 - matrix2.M13;
+            result.M14 = matrix1.M14 - matrix2.M14;
+            result.M21 = matrix1.M21 - matrix2.M21;
+            result.M22 = matrix1.M22 - matrix2.M22;
+            result.M23 = matrix1.M23 - matrix2.M23;
+            result.M24 = matrix1.M24 - matrix2.M24;
+            result.M31 = matrix1.M31 - matrix2.M31;
+            result.M32 = matrix1.M32 - matrix2.M32;
+            result.M33 = matrix1.M33 - matrix2.M33;
+            result.M34 = matrix1.M34 - matrix2.M34;
+            result.M41 = matrix1.M41 - matrix2.M41;
+            result.M42 = matrix1.M42 - matrix2.M42;
+            result.M43 = matrix1.M43 - matrix2.M43;
+            result.M44 = matrix1.M44 - matrix2.M44;
+        }
+
+        public static Matrix Transpose(Matrix matrix)
+        {
+            Matrix result;
+
+            result.M11 = matrix.M11;
+            result.M12 = matrix.M21;
+            result.M13 = matrix.M31;
+            result.M14 = matrix.M41;
+
+            result.M21 = matrix.M12;
+            result.M22 = matrix.M22;
+            result.M23 = matrix.M32;
+            result.M24 = matrix.M42;
+
+            result.M31 = matrix.M13;
+            result.M32 = matrix.M23;
+            result.M33 = matrix.M33;
+            result.M34 = matrix.M43;
+
+            result.M41 = matrix.M14;
+            result.M42 = matrix.M24;
+            result.M43 = matrix.M34;
+            result.M44 = matrix.M44;
+
+            return result;
+        }
+
+
+        public static void Transpose(ref Matrix matrix, out Matrix result)
+        {
+            result.M11 = matrix.M11;
+            result.M12 = matrix.M21;
+            result.M13 = matrix.M31;
+            result.M14 = matrix.M41;
+
+            result.M21 = matrix.M12;
+            result.M22 = matrix.M22;
+            result.M23 = matrix.M32;
+            result.M24 = matrix.M42;
+
+            result.M31 = matrix.M13;
+            result.M32 = matrix.M23;
+            result.M33 = matrix.M33;
+            result.M34 = matrix.M43;
+
+            result.M41 = matrix.M14;
+            result.M42 = matrix.M24;
+            result.M43 = matrix.M34;
+            result.M44 = matrix.M44;
+        }
+
+        #endregion Public Static Methods
+
+        #region Public Methods
+
+        public float Determinant()
+        {
+            float minor1, minor2, minor3, minor4, minor5, minor6;
+
+            minor1 = M31 * M42 - M32 * M41;
+            minor2 = M31 * M43 - M33 * M41;
+            minor3 = M31 * M44 - M34 * M41;
+            minor4 = M32 * M43 - M33 * M42;
+            minor5 = M32 * M44 - M34 * M42;
+            minor6 = M33 * M44 - M34 * M43;
+
+            return M11 * (M22 * minor6 - M23 * minor5 + M24 * minor4) -
+                            M12 * (M21 * minor6 - M23 * minor3 + M24 * minor2) +
+                            M13 * (M21 * minor5 - M22 * minor3 + M24 * minor1) -
+                            M14 * (M21 * minor4 - M22 * minor2 + M23 * minor1);
+        }
+
+        public bool Equals(Matrix other)
+        {
+            return (this.M11 == other.M11) && (this.M12 == other.M12) &&
+                   (this.M13 == other.M13) && (this.M14 == other.M14) &&
+                   (this.M21 == other.M21) && (this.M22 == other.M22) &&
+                   (this.M23 == other.M23) && (this.M24 == other.M24) &&
+                   (this.M31 == other.M31) && (this.M32 == other.M32) &&
+                   (this.M33 == other.M33) && (this.M34 == other.M34) &&
+                   (this.M41 == other.M41) && (this.M42 == other.M42) &&
+                   (this.M43 == other.M43) && (this.M44 == other.M44);
+        }
+
+        #endregion Public Methods
+
+        #region Operators
+
+        public static Matrix operator +(Matrix matrix1, Matrix matrix2)
+        {
+            matrix1.M11 += matrix2.M11;
+            matrix1.M12 += matrix2.M12;
+            matrix1.M13 += matrix2.M13;
+            matrix1.M14 += matrix2.M14;
+            matrix1.M21 += matrix2.M21;
+            matrix1.M22 += matrix2.M22;
+            matrix1.M23 += matrix2.M23;
+            matrix1.M24 += matrix2.M24;
+            matrix1.M31 += matrix2.M31;
+            matrix1.M32 += matrix2.M32;
+            matrix1.M33 += matrix2.M33;
+            matrix1.M34 += matrix2.M34;
+            matrix1.M41 += matrix2.M41;
+            matrix1.M42 += matrix2.M42;
+            matrix1.M43 += matrix2.M43;
+            matrix1.M44 += matrix2.M44;
+            return matrix1;
+        }
+
+        public static Matrix operator /(Matrix matrix1, Matrix matrix2)
+        {
+            Matrix inverse = Matrix.Invert(matrix2), result;
+
+            result.M11 = matrix1.M11 * inverse.M11 + matrix1.M12 * inverse.M21 + matrix1.M13 * inverse.M31 + matrix1.M14 * inverse.M41;
+            result.M12 = matrix1.M11 * inverse.M12 + matrix1.M12 * inverse.M22 + matrix1.M13 * inverse.M32 + matrix1.M14 * inverse.M42;
+            result.M13 = matrix1.M11 * inverse.M13 + matrix1.M12 * inverse.M23 + matrix1.M13 * inverse.M33 + matrix1.M14 * inverse.M43;
+            result.M14 = matrix1.M11 * inverse.M14 + matrix1.M12 * inverse.M24 + matrix1.M13 * inverse.M34 + matrix1.M14 * inverse.M44;
+
+            result.M21 = matrix1.M21 * inverse.M11 + matrix1.M22 * inverse.M21 + matrix1.M23 * inverse.M31 + matrix1.M24 * inverse.M41;
+            result.M22 = matrix1.M21 * inverse.M12 + matrix1.M22 * inverse.M22 + matrix1.M23 * inverse.M32 + matrix1.M24 * inverse.M42;
+            result.M23 = matrix1.M21 * inverse.M13 + matrix1.M22 * inverse.M23 + matrix1.M23 * inverse.M33 + matrix1.M24 * inverse.M43;
+            result.M24 = matrix1.M21 * inverse.M14 + matrix1.M22 * inverse.M24 + matrix1.M23 * inverse.M34 + matrix1.M24 * inverse.M44;
+
+            result.M31 = matrix1.M31 * inverse.M11 + matrix1.M32 * inverse.M21 + matrix1.M33 * inverse.M31 + matrix1.M34 * inverse.M41;
+            result.M32 = matrix1.M31 * inverse.M12 + matrix1.M32 * inverse.M22 + matrix1.M33 * inverse.M32 + matrix1.M34 * inverse.M42;
+            result.M33 = matrix1.M31 * inverse.M13 + matrix1.M32 * inverse.M23 + matrix1.M33 * inverse.M33 + matrix1.M34 * inverse.M43;
+            result.M34 = matrix1.M31 * inverse.M14 + matrix1.M32 * inverse.M24 + matrix1.M33 * inverse.M34 + matrix1.M34 * inverse.M44;
+
+            result.M41 = matrix1.M41 * inverse.M11 + matrix1.M42 * inverse.M21 + matrix1.M43 * inverse.M31 + matrix1.M44 * inverse.M41;
+            result.M42 = matrix1.M41 * inverse.M12 + matrix1.M42 * inverse.M22 + matrix1.M43 * inverse.M32 + matrix1.M44 * inverse.M42;
+            result.M43 = matrix1.M41 * inverse.M13 + matrix1.M42 * inverse.M23 + matrix1.M43 * inverse.M33 + matrix1.M44 * inverse.M43;
+            result.M44 = matrix1.M41 * inverse.M14 + matrix1.M42 * inverse.M24 + matrix1.M43 * inverse.M34 + matrix1.M44 * inverse.M44;
+
+            return result;
+        }
+
+        public static Matrix operator /(Matrix matrix1, float divider)
+        {
+            float inverseDivider = 1.0f / divider;
+
+            matrix1.M11 = matrix1.M11 * inverseDivider;
+            matrix1.M12 = matrix1.M12 * inverseDivider;
+            matrix1.M13 = matrix1.M13 * inverseDivider;
+            matrix1.M14 = matrix1.M14 * inverseDivider;
+            matrix1.M21 = matrix1.M21 * inverseDivider;
+            matrix1.M22 = matrix1.M22 * inverseDivider;
+            matrix1.M23 = matrix1.M23 * inverseDivider;
+            matrix1.M24 = matrix1.M24 * inverseDivider;
+            matrix1.M31 = matrix1.M31 * inverseDivider;
+            matrix1.M32 = matrix1.M32 * inverseDivider;
+            matrix1.M33 = matrix1.M33 * inverseDivider;
+            matrix1.M34 = matrix1.M34 * inverseDivider;
+            matrix1.M41 = matrix1.M41 * inverseDivider;
+            matrix1.M42 = matrix1.M42 * inverseDivider;
+            matrix1.M43 = matrix1.M43 * inverseDivider;
+            matrix1.M44 = matrix1.M44 * inverseDivider;
+
+            return matrix1;
+        }
+
+        public static bool operator ==(Matrix matrix1, Matrix matrix2)
+        {
+            return (matrix1.M11 == matrix2.M11) && (matrix1.M12 == matrix2.M12) &&
+                   (matrix1.M13 == matrix2.M13) && (matrix1.M14 == matrix2.M14) &&
+                   (matrix1.M21 == matrix2.M21) && (matrix1.M22 == matrix2.M22) &&
+                   (matrix1.M23 == matrix2.M23) && (matrix1.M24 == matrix2.M24) &&
+                   (matrix1.M31 == matrix2.M31) && (matrix1.M32 == matrix2.M32) &&
+                   (matrix1.M33 == matrix2.M33) && (matrix1.M34 == matrix2.M34) &&
+                   (matrix1.M41 == matrix2.M41) && (matrix1.M42 == matrix2.M42) &&
+                   (matrix1.M43 == matrix2.M43) && (matrix1.M44 == matrix2.M44);
+        }
+
+        public static bool operator !=(Matrix matrix1, Matrix matrix2)
+        {
+            return (matrix1.M11 != matrix2.M11) || (matrix1.M12 != matrix2.M12) ||
+                   (matrix1.M13 != matrix2.M13) || (matrix1.M14 != matrix2.M14) ||
+                   (matrix1.M21 != matrix2.M21) || (matrix1.M22 != matrix2.M22) ||
+                   (matrix1.M23 != matrix2.M23) || (matrix1.M24 != matrix2.M24) ||
+                   (matrix1.M31 != matrix2.M31) || (matrix1.M32 != matrix2.M32) ||
+                   (matrix1.M33 != matrix2.M33) || (matrix1.M34 != matrix2.M34) ||
+                   (matrix1.M41 != matrix2.M41) || (matrix1.M42 != matrix2.M42) ||
+                   (matrix1.M43 != matrix2.M43) || (matrix1.M44 != matrix2.M44);
+        }
+
+        public static Matrix operator *(Matrix matrix1, Matrix matrix2)
+        {
+            Matrix result;
+
+            result.M11 = matrix1.M11 * matrix2.M11 + matrix1.M12 * matrix2.M21 + matrix1.M13 * matrix2.M31 + matrix1.M14 * matrix2.M41;
+            result.M12 = matrix1.M11 * matrix2.M12 + matrix1.M12 * matrix2.M22 + matrix1.M13 * matrix2.M32 + matrix1.M14 * matrix2.M42;
+            result.M13 = matrix1.M11 * matrix2.M13 + matrix1.M12 * matrix2.M23 + matrix1.M13 * matrix2.M33 + matrix1.M14 * matrix2.M43;
+            result.M14 = matrix1.M11 * matrix2.M14 + matrix1.M12 * matrix2.M24 + matrix1.M13 * matrix2.M34 + matrix1.M14 * matrix2.M44;
+
+            result.M21 = matrix1.M21 * matrix2.M11 + matrix1.M22 * matrix2.M21 + matrix1.M23 * matrix2.M31 + matrix1.M24 * matrix2.M41;
+            result.M22 = matrix1.M21 * matrix2.M12 + matrix1.M22 * matrix2.M22 + matrix1.M23 * matrix2.M32 + matrix1.M24 * matrix2.M42;
+            result.M23 = matrix1.M21 * matrix2.M13 + matrix1.M22 * matrix2.M23 + matrix1.M23 * matrix2.M33 + matrix1.M24 * matrix2.M43;
+            result.M24 = matrix1.M21 * matrix2.M14 + matrix1.M22 * matrix2.M24 + matrix1.M23 * matrix2.M34 + matrix1.M24 * matrix2.M44;
+
+            result.M31 = matrix1.M31 * matrix2.M11 + matrix1.M32 * matrix2.M21 + matrix1.M33 * matrix2.M31 + matrix1.M34 * matrix2.M41;
+            result.M32 = matrix1.M31 * matrix2.M12 + matrix1.M32 * matrix2.M22 + matrix1.M33 * matrix2.M32 + matrix1.M34 * matrix2.M42;
+            result.M33 = matrix1.M31 * matrix2.M13 + matrix1.M32 * matrix2.M23 + matrix1.M33 * matrix2.M33 + matrix1.M34 * matrix2.M43;
+            result.M34 = matrix1.M31 * matrix2.M14 + matrix1.M32 * matrix2.M24 + matrix1.M33 * matrix2.M34 + matrix1.M34 * matrix2.M44;
+
+            result.M41 = matrix1.M41 * matrix2.M11 + matrix1.M42 * matrix2.M21 + matrix1.M43 * matrix2.M31 + matrix1.M44 * matrix2.M41;
+            result.M42 = matrix1.M41 * matrix2.M12 + matrix1.M42 * matrix2.M22 + matrix1.M43 * matrix2.M32 + matrix1.M44 * matrix2.M42;
+            result.M43 = matrix1.M41 * matrix2.M13 + matrix1.M42 * matrix2.M23 + matrix1.M43 * matrix2.M33 + matrix1.M44 * matrix2.M43;
+            result.M44 = matrix1.M41 * matrix2.M14 + matrix1.M42 * matrix2.M24 + matrix1.M43 * matrix2.M34 + matrix1.M44 * matrix2.M44;
+
+            return result;
+        }
+
+        public static Matrix operator *(Matrix matrix, float scaleFactor)
+        {
+            matrix.M11 = matrix.M11 * scaleFactor;
+            matrix.M12 = matrix.M12 * scaleFactor;
+            matrix.M13 = matrix.M13 * scaleFactor;
+            matrix.M14 = matrix.M14 * scaleFactor;
+            matrix.M21 = matrix.M21 * scaleFactor;
+            matrix.M22 = matrix.M22 * scaleFactor;
+            matrix.M23 = matrix.M23 * scaleFactor;
+            matrix.M24 = matrix.M24 * scaleFactor;
+            matrix.M31 = matrix.M31 * scaleFactor;
+            matrix.M32 = matrix.M32 * scaleFactor;
+            matrix.M33 = matrix.M33 * scaleFactor;
+            matrix.M34 = matrix.M34 * scaleFactor;
+            matrix.M41 = matrix.M41 * scaleFactor;
+            matrix.M42 = matrix.M42 * scaleFactor;
+            matrix.M43 = matrix.M43 * scaleFactor;
+            matrix.M44 = matrix.M44 * scaleFactor;
+            return matrix;
+        }
+
+        public static Matrix operator *(float scaleFactor, Matrix matrix)
+        {
+            matrix.M11 = matrix.M11 * scaleFactor;
+            matrix.M12 = matrix.M12 * scaleFactor;
+            matrix.M13 = matrix.M13 * scaleFactor;
+            matrix.M14 = matrix.M14 * scaleFactor;
+            matrix.M21 = matrix.M21 * scaleFactor;
+            matrix.M22 = matrix.M22 * scaleFactor;
+            matrix.M23 = matrix.M23 * scaleFactor;
+            matrix.M24 = matrix.M24 * scaleFactor;
+            matrix.M31 = matrix.M31 * scaleFactor;
+            matrix.M32 = matrix.M32 * scaleFactor;
+            matrix.M33 = matrix.M33 * scaleFactor;
+            matrix.M34 = matrix.M34 * scaleFactor;
+            matrix.M41 = matrix.M41 * scaleFactor;
+            matrix.M42 = matrix.M42 * scaleFactor;
+            matrix.M43 = matrix.M43 * scaleFactor;
+            matrix.M44 = matrix.M44 * scaleFactor;
+            return matrix;
+        }
+
+        public static Matrix operator -(Matrix matrix1, Matrix matrix2)
+        {
+            matrix1.M11 -= matrix2.M11;
+            matrix1.M12 -= matrix2.M12;
+            matrix1.M13 -= matrix2.M13;
+            matrix1.M14 -= matrix2.M14;
+            matrix1.M21 -= matrix2.M21;
+            matrix1.M22 -= matrix2.M22;
+            matrix1.M23 -= matrix2.M23;
+            matrix1.M24 -= matrix2.M24;
+            matrix1.M31 -= matrix2.M31;
+            matrix1.M32 -= matrix2.M32;
+            matrix1.M33 -= matrix2.M33;
+            matrix1.M34 -= matrix2.M34;
+            matrix1.M41 -= matrix2.M41;
+            matrix1.M42 -= matrix2.M42;
+            matrix1.M43 -= matrix2.M43;
+            matrix1.M44 -= matrix2.M44;
+            return matrix1;
+        }
+
+
+        public static Matrix operator -(Matrix matrix)
+        {
+            matrix.M11 = -matrix.M11;
+            matrix.M12 = -matrix.M12;
+            matrix.M13 = -matrix.M13;
+            matrix.M14 = -matrix.M14;
+            matrix.M21 = -matrix.M21;
+            matrix.M22 = -matrix.M22;
+            matrix.M23 = -matrix.M23;
+            matrix.M24 = -matrix.M24;
+            matrix.M31 = -matrix.M31;
+            matrix.M32 = -matrix.M32;
+            matrix.M33 = -matrix.M33;
+            matrix.M34 = -matrix.M34;
+            matrix.M41 = -matrix.M41;
+            matrix.M42 = -matrix.M42;
+            matrix.M43 = -matrix.M43;
+            matrix.M44 = -matrix.M44;
+            return matrix;
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix)
+                return this == (Matrix)obj;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return "{ {M11:" + M11 + " M12:" + M12 + " M13:" + M13 + " M14:" + M14 + "}" +
+                    " {M21:" + M21 + " M22:" + M22 + " M23:" + M23 + " M24:" + M24 + "}" +
+                    " {M31:" + M31 + " M32:" + M32 + " M33:" + M33 + " M34:" + M34 + "}" +
+                    " {M41:" + M41 + " M42:" + M42 + " M43:" + M43 + " M44:" + M44 + "} }";
+        }
+
+        #endregion
+
+    }
+}

--- a/Assets/Cube Loader/src/Microsoft.Xna/Matrix.cs.meta
+++ b/Assets/Cube Loader/src/Microsoft.Xna/Matrix.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3c9bb5a3a8006e44aa9a27ddcecd9f1d
+timeCreated: 1429899092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Model.meta
+++ b/Assets/Cube Loader/src/Model.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8b4a791123265e44696b94e15b32f88b
+folderAsset: yes
+timeCreated: 1429899091
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Model/Intersection.cs
+++ b/Assets/Cube Loader/src/Model/Intersection.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Pyrite.Client.Model
+{
+    public class Intersection<TObject>
+    {
+        private readonly bool hasHit = false;
+
+        public Intersection()
+        {
+            this.Position = Vector3.zero;
+            this.Normal = Vector3.zero;
+            this.Ray = new Ray();
+            this.Distance = float.MaxValue;
+            this.Object = default(TObject);
+        }
+
+        public Intersection(Vector3 hitPos, Vector3 hitNormal, Ray ray, double distance)
+        {
+            this.Position = hitPos;
+            this.Normal = hitNormal;
+            this.Ray = ray;
+            this.Distance = distance;
+            this.hasHit = true;
+        }
+
+        public Intersection(TObject hitObject = default(TObject))
+        {
+            this.hasHit = hitObject != null;
+            this.Object = hitObject;
+            this.Position = Vector3.zero;
+            this.Normal = Vector3.zero;
+            this.Ray = new Ray();
+            this.Distance = 0.0f;
+        }
+
+        public double Distance { get; private set; }
+
+        public bool HasHit
+        {
+            get { return this.hasHit; }
+        }
+
+        public Vector3 Normal { get; private set; }
+        public TObject Object { get; set; }
+        public TObject OtherObject { get; set; }
+        public Vector3 Position { get; private set; }
+        public Ray Ray { get; private set; }
+
+        public override bool Equals(object otherRecord)
+        {
+            Intersection<TObject> o = (Intersection<TObject>)otherRecord;
+            return o.Equals(this);
+        }
+    }
+}

--- a/Assets/Cube Loader/src/Model/Intersection.cs
+++ b/Assets/Cube Loader/src/Model/Intersection.cs
@@ -10,14 +10,14 @@ namespace Pyrite.Client.Model
     {
         private readonly bool hasHit = false;
 
-        public Intersection()
-        {
-            this.Position = Vector3.zero;
-            this.Normal = Vector3.zero;
-            this.Ray = new Ray();
-            this.Distance = float.MaxValue;
-            this.Object = default(TObject);
-        }
+        //public Intersection()
+        //{
+        //    this.Position = Vector3.zero;
+        //    this.Normal = Vector3.zero;
+        //    this.Ray = new Ray();
+        //    this.Distance = float.MaxValue;
+        //    this.Object = default(TObject);
+        //}
 
         public Intersection(Vector3 hitPos, Vector3 hitNormal, Ray ray, double distance)
         {

--- a/Assets/Cube Loader/src/Model/Intersection.cs.meta
+++ b/Assets/Cube Loader/src/Model/Intersection.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 292d1b124e12e454e95b36e445e27ad0
+timeCreated: 1429899091
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cube Loader/src/Model/OcTree.cs
+++ b/Assets/Cube Loader/src/Model/OcTree.cs
@@ -1,0 +1,763 @@
+﻿using Microsoft.Xna.Framework;
+using Pyrite.Client.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Pyrite.Client.Model
+{
+    public class OcTree<TObject> where TObject : IBounds<TObject>
+    {
+        private const int DEFAULT_MIN_SIZE = 1;
+        private static readonly IEnumerable<Intersection<TObject>> NoIntersections = new Intersection<TObject>[] { };
+
+        private readonly uint[] debruijnPosition =
+        {
+            0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26,
+            5, 4, 31
+        };
+
+        private readonly Queue<TObject> insertionQueue = new Queue<TObject>();
+
+        private readonly int minimumSize = DEFAULT_MIN_SIZE;
+        private readonly List<TObject> objects;
+        private readonly OcTree<TObject>[] octants = new OcTree<TObject>[8];
+
+        private byte activeOctants = 0;
+
+        private OcTree<TObject> parent;
+        private BoundingBox region;
+        private bool treeBuilt = false;
+        private bool treeReady = false;
+
+        public OcTree()
+            : this(new BoundingBox(Vector3.zero, Vector3.zero))
+        {
+        }
+
+        public OcTree(BoundingBox region)
+            : this(region, new TObject[] { })
+        {
+        }
+
+        public OcTree(BoundingBox region, IEnumerable<TObject> objList)
+            : this(region, objList, DEFAULT_MIN_SIZE)
+        {
+        }
+
+        public OcTree(BoundingBox region, IEnumerable<TObject> objList, int minSize)
+        {
+            this.region = region;
+            this.objects = new List<TObject>(objList);
+            this.minimumSize = minSize;
+        }
+
+        public bool HasChildren
+        {
+            get { return this.activeOctants != 0; }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                if (this.objects.Count != 0)
+                {
+                    return false;
+                }
+
+                if (this.activeOctants != 0)
+                {
+                    for (int a = 0; a < 8; a++)
+                    {
+                        if (this.octants[a] != null && !this.octants[a].IsEmpty)
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public bool IsRoot
+        {
+            get { return this.parent == null; }
+        }
+
+        public IList<TObject> Items
+        {
+            get { return this.objects; }
+        }
+
+        public int MinimumSize
+        {
+            get { return this.minimumSize; }
+        }
+
+        public byte OctantMask
+        {
+            get { return this.activeOctants; }
+        }
+
+        public OcTree<TObject>[] Octants
+        {
+            get { return this.octants; }
+        }
+
+        public BoundingBox Region
+        {
+            get { return this.region; }
+        }
+
+        public override string ToString()
+        {
+            return String.Format(
+                "Region:{0} Children:{1}b Objects:{2}",
+                this.Region,
+                Convert.ToString(this.activeOctants, 2).PadLeft(8, '0'),
+                this.objects.Count);
+        }
+
+        public void Add(IEnumerable<TObject> items)
+        {
+            foreach (TObject item in items)
+            {
+                this.insertionQueue.Enqueue(item);
+                this.treeReady = false;
+            }
+        }
+
+        public void Add(TObject item)
+        {
+            this.Add(new[] { item });
+        }
+
+        public IEnumerable<Intersection<TObject>> AllIntersections(Ray ray)
+        {
+            if (!this.treeReady)
+            {
+                this.UpdateTree();
+            }
+
+            return this.GetIntersection(ray);
+        }
+
+        public IEnumerable<Intersection<TObject>> AllIntersections(BoundingFrustum frustrum)
+        {
+            if (!this.treeReady)
+            {
+                this.UpdateTree();
+            }
+
+            return this.GetIntersection(frustrum);
+        }
+
+        public IEnumerable<Intersection<TObject>> AllIntersections(BoundingBox box)
+        {
+            if (!this.treeReady)
+            {
+                this.UpdateTree();
+            }
+
+            return this.GetIntersection(box);
+        }
+
+        public IEnumerable<Intersection<TObject>> AllIntersections(BoundingSphere sphere)
+        {
+            if (!this.treeReady)
+            {
+                this.UpdateTree();
+            }
+
+            return this.GetIntersection(sphere);
+        }
+
+        public IEnumerable<TObject> AllItems()
+        {
+            foreach (TObject obj in this.objects)
+            {
+                yield return obj;
+            }
+
+            if (this.activeOctants == 0)
+            {
+                yield break;
+            }
+
+            for (int index = 0; index < 8; index++)
+            {
+                if (this.octants[index] == null)
+                {
+                    continue;
+                }
+
+                foreach (TObject obj in this.octants[index].AllItems())
+                {
+                    yield return obj;
+                }
+            }
+        }
+
+        public Intersection<TObject> NearestIntersection(Ray ray)
+        {
+            if (!this.treeReady)
+            {
+                this.UpdateTree();
+            }
+
+            IEnumerable<Intersection<TObject>> intersections = this.GetIntersection(ray);
+
+            Intersection<TObject> nearest = new Intersection<TObject>();
+
+            foreach (Intersection<TObject> ir in intersections)
+            {
+                if (nearest.HasHit == false)
+                {
+                    nearest = ir;
+                    continue;
+                }
+
+                if (ir.Distance < nearest.Distance)
+                {
+                    nearest = ir;
+                }
+            }
+
+            return nearest;
+        }
+
+        public void Remove(TObject item)
+        {
+            this.objects.Remove(item);
+        }
+
+        public void UpdateTree()
+        {
+            if (!this.treeBuilt)
+            {
+                while (this.insertionQueue.Count != 0)
+                {
+                    this.objects.Add(this.insertionQueue.Dequeue());
+                }
+                this.BuildTree();
+            }
+            else
+            {
+                while (this.insertionQueue.Count != 0)
+                {
+                    this.Insert(this.insertionQueue.Dequeue());
+                }
+            }
+
+            this.treeReady = true;
+        }
+
+        private void BuildTree()
+        {
+            if (this.objects.Count <= 1)
+            {
+                return;
+            }
+
+            Vector3 dimensions = this.region.Max - this.region.Min;
+
+            if (dimensions == Vector3.zero)
+            {
+                this.SetEnclosingCube();
+                dimensions = this.region.Max - this.region.Min;
+            }
+
+            //Check to see if the dimensions of the box are greater than the minimum dimensions
+            if (dimensions.x <= this.minimumSize && dimensions.y <= this.minimumSize && dimensions.z <= this.minimumSize)
+            {
+                return;
+            }
+
+            Vector3 half = dimensions / 2.0f;
+            Vector3 center = this.region.Min + half;
+
+            BoundingBox[] octant = new BoundingBox[8];
+            octant[0] = new BoundingBox(this.region.Min, center);
+            octant[1] = new BoundingBox(new Vector3(center.x, this.region.Min.y, this.region.Min.z), new Vector3(this.region.Max.x, center.x, center.z));
+            octant[2] = new BoundingBox(new Vector3(center.x, this.region.Min.y, center.z), new Vector3(this.region.Max.x, center.x, this.region.Max.z));
+            octant[3] = new BoundingBox(new Vector3(this.region.Min.x, this.region.Min.y, center.z), new Vector3(center.x, center.x, this.region.Max.z));
+            octant[4] = new BoundingBox(new Vector3(this.region.Min.x, center.x, this.region.Min.z), new Vector3(center.x, this.region.Max.y, center.z));
+            octant[5] = new BoundingBox(new Vector3(center.x, center.x, this.region.Min.z), new Vector3(this.region.Max.x, this.region.Max.y, center.z));
+            octant[6] = new BoundingBox(center, this.region.Max);
+            octant[7] = new BoundingBox(new Vector3(this.region.Min.x, center.x, center.z), new Vector3(center.x, this.region.Max.y, this.region.Max.z));
+
+            //This will contain all of our objects which fit within each respective octant.
+            List<TObject>[] octList = new List<TObject>[8];
+            for (int i = 0; i < 8; i++)
+            {
+                octList[i] = new List<TObject>();
+            }
+
+            //this list contains all of the objects which got moved down the tree and can be delisted from this node.
+            List<TObject> delist = new List<TObject>();
+
+            foreach (TObject obj in this.objects)
+            {
+                if (obj.BoundingBox.Min != obj.BoundingBox.Max)
+                {
+                    for (int a = 0; a < 8; a++)
+                    {
+                        if (octant[a].Contains(obj.BoundingBox) == ContainmentType.Contains)
+                        {
+                            octList[a].Add(obj);
+                            delist.Add(obj);
+                            break;
+                        }
+                    }
+                }
+                else if (!obj.BoundingSphere.Radius.Equals(0f))
+                {
+                    for (int a = 0; a < 8; a++)
+                    {
+                        if (octant[a].Contains(obj.BoundingSphere) == ContainmentType.Contains)
+                        {
+                            octList[a].Add(obj);
+                            delist.Add(obj);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            foreach (TObject obj in delist)
+            {
+                this.objects.Remove(obj);
+            }
+
+            //Create child nodes where there are items contained in the bounding region
+            for (int a = 0; a < 8; a++)
+            {
+                if (octList[a].Count != 0)
+                {
+                    this.octants[a] = this.CreateNode(octant[a], octList[a]);
+                    this.activeOctants |= (byte)(1 << a);
+                    this.octants[a].BuildTree();
+                }
+            }
+
+            this.treeBuilt = true;
+            this.treeReady = true;
+        }
+
+        private OcTree<TObject> CreateNode(BoundingBox boundingBox, IEnumerable<TObject> objList) //complete & tested
+        {
+            if (!objList.Any())
+            {
+                return null;
+            }
+
+            OcTree<TObject> ret = new OcTree<TObject>(boundingBox, objList, this.MinimumSize);
+            ret.parent = this;
+
+            return ret;
+        }
+
+        private OcTree<TObject> CreateNode(BoundingBox boundingBox, TObject item)
+        {
+            OcTree<TObject> ret = new OcTree<TObject>(boundingBox, new[] { item }, this.MinimumSize);
+            ret.parent = this;
+            return ret;
+        }
+
+        private IEnumerable<Intersection<TObject>> GetIntersection(BoundingBox box)
+        {
+            if (this.objects.Count == 0 && this.HasChildren == false)
+            {
+                yield break;
+            }
+
+            ContainmentType boxContains = box.Contains(this.region);
+            switch (boxContains)
+            {
+                case ContainmentType.Contains:
+                    {
+                        // everything in this octree is
+                        // contained in within the box
+                        foreach (var ir in this.AllItems().Select(item => new Intersection<TObject>(item)))
+                        {
+                            yield return ir;
+                        }
+                        break;
+                    }
+
+                case ContainmentType.Intersects:
+                    {
+                        foreach (TObject obj in this.objects)
+                        {
+                            // test for intersection
+                            Intersection<TObject> ir = obj.Intersects(box);
+                            if (ir != null)
+                            {
+                                yield return ir;
+                            }
+                        }
+
+                        for (int a = 0; a < 8; a++)
+                        {
+                            if (this.octants[a] == null)
+                            {
+                                continue;
+                            }
+
+                            IEnumerable<Intersection<TObject>> hitList = this.octants[a].GetIntersection(box);
+                            foreach (var ir in hitList)
+                            {
+                                yield return ir;
+                            }
+                        }
+                        break;
+                    }
+
+                default:
+                    {
+                        break;
+                    }
+            }
+        }
+
+        private IEnumerable<Intersection<TObject>> GetIntersection(BoundingFrustum frustum)
+        {
+            if (this.objects.Count == 0 && this.HasChildren == false)
+            {
+                return NoIntersections;
+            }
+
+            List<Intersection<TObject>> ret = new List<Intersection<TObject>>();
+
+            foreach (TObject obj in this.objects)
+            {
+                Intersection<TObject> ir = obj.Intersects(frustum);
+                if (ir != null)
+                {
+                    ret.Add(ir);
+                }
+            }
+
+            for (int a = 0; a < 8; a++)
+            {
+                if (this.octants[a] == null)
+                {
+                    continue;
+                }
+
+                BoundingBox octantRegion = this.octants[a].region;
+                ContainmentType frustumContains = frustum.Contains(octantRegion);
+
+                if ((frustumContains == ContainmentType.Intersects || frustumContains == ContainmentType.Contains))
+                {
+                    IEnumerable<Intersection<TObject>> hitList = this.octants[a].GetIntersection(frustum);
+                    ret.AddRange(hitList);
+                }
+            }
+            return ret;
+        }
+
+        private IEnumerable<Intersection<TObject>> GetIntersection(BoundingSphere sphere)
+        {
+            if (this.objects.Count == 0 && this.HasChildren == false)
+            {
+                return NoIntersections;
+            }
+
+            List<Intersection<TObject>> ret = new List<Intersection<TObject>>();
+
+            foreach (TObject obj in this.objects)
+            {
+                Trace.WriteLine(obj.ToString());
+                Intersection<TObject> ir = obj.Intersects(sphere);
+                if (ir != null)
+                {
+                    ret.Add(ir);
+                }
+            }
+
+            for (int a = 0; a < 8; a++)
+            {
+                if (this.octants[a] == null)
+                {
+                    continue;
+                }
+
+                BoundingBox octantRegion = this.octants[a].region;
+                ContainmentType sphereContains = sphere.Contains(octantRegion);
+
+                if ((sphereContains == ContainmentType.Intersects || sphereContains == ContainmentType.Contains))
+                {
+                    IEnumerable<Intersection<TObject>> hitList = this.octants[a].GetIntersection(sphere);
+                    ret.AddRange(hitList);
+                }
+            }
+
+            return ret;
+        }
+
+        private IEnumerable<Intersection<TObject>> GetIntersection(Ray intersectRay)
+        {
+            if (this.objects.Count == 0 && this.HasChildren == false) //terminator for any recursion
+            {
+                return NoIntersections;
+            }
+
+            List<Intersection<TObject>> ret = new List<Intersection<TObject>>();
+
+            //the ray is intersecting this region, so we have to check for intersection with all of our contained objects and child regions.
+
+            //test each object in the list for intersection
+            foreach (TObject obj in this.objects)
+            {
+                if (obj.BoundingBox.Intersects(intersectRay) != null)
+                {
+                    Intersection<TObject> ir = obj.Intersects(intersectRay);
+                    if (ir.HasHit)
+                    {
+                        ret.Add(ir);
+                    }
+                }
+            }
+
+            // test each child octant for intersection
+            for (int a = 0; a < 8; a++)
+            {
+                if (this.octants[a] != null && this.octants[a].region.Intersects(intersectRay) != null)
+                {
+                    IEnumerable<Intersection<TObject>> hits = this.octants[a].GetIntersection(intersectRay);
+                    ret.AddRange(hits);
+                }
+            }
+
+            return ret;
+        }
+
+        private void Insert(TObject item)
+        {
+            /*make sure we're not inserting an object any deeper into the tree than we have to.
+                -if the current node is an empty leaf node, just insert and leave it.*/
+            if (this.objects.Count <= 1 && this.activeOctants == 0)
+            {
+                this.objects.Add(item);
+                return;
+            }
+
+            Vector3 dimensions = this.region.Max - this.region.Min;
+            //Check to see if the dimensions of the box are greater than the minimum dimensions
+            if (dimensions.x <= this.minimumSize && dimensions.y <= this.minimumSize && dimensions.z <= this.minimumSize)
+            {
+                this.objects.Add(item);
+                return;
+            }
+            Vector3 half = dimensions / 2.0f;
+            Vector3 center = this.region.Min + half;
+
+            //Find or create subdivided regions for each octant in the current region
+            BoundingBox[] childOctant = new BoundingBox[8];
+            childOctant[0] = (this.octants[0] != null) ? this.octants[0].region : new BoundingBox(this.region.Min, center);
+            childOctant[1] = (this.octants[1] != null)
+                ? this.octants[1].region
+                : new BoundingBox(new Vector3(center.x, this.region.Min.y, this.region.Min.z), new Vector3(this.region.Max.x, center.x, center.z));
+            childOctant[2] = (this.octants[2] != null)
+                ? this.octants[2].region
+                : new BoundingBox(new Vector3(center.x, this.region.Min.y, center.z), new Vector3(this.region.Max.x, center.x, this.region.Max.z));
+            childOctant[3] = (this.octants[3] != null)
+                ? this.octants[3].region
+                : new BoundingBox(new Vector3(this.region.Min.x, this.region.Min.y, center.z), new Vector3(center.x, center.x, this.region.Max.z));
+            childOctant[4] = (this.octants[4] != null)
+                ? this.octants[4].region
+                : new BoundingBox(new Vector3(this.region.Min.x, center.x, this.region.Min.z), new Vector3(center.x, this.region.Max.y, center.z));
+            childOctant[5] = (this.octants[5] != null)
+                ? this.octants[5].region
+                : new BoundingBox(new Vector3(center.x, center.x, this.region.Min.z), new Vector3(this.region.Max.x, this.region.Max.y, center.z));
+            childOctant[6] = (this.octants[6] != null) ? this.octants[6].region : new BoundingBox(center, this.region.Max);
+            childOctant[7] = (this.octants[7] != null)
+                ? this.octants[7].region
+                : new BoundingBox(new Vector3(this.region.Min.x, center.x, center.z), new Vector3(center.x, this.region.Max.y, this.region.Max.z));
+
+            if (item.BoundingBox.Max != item.BoundingBox.Min && this.region.Contains(item.BoundingBox) == ContainmentType.Contains)
+            {
+                bool found = false;
+
+                // we will try to place the object into a child node. If we can't fit it in a child node, then we insert it into the current node object list.
+                for (int a = 0; a < 8; a++)
+                {
+                    //is the object fully contained within a quadrant?
+                    if (childOctant[a].Contains(item.BoundingBox) == ContainmentType.Contains)
+                    {
+                        if (this.octants[a] != null)
+                        {
+                            this.octants[a].Insert(item); //Add the item into that tree and let the child tree figure out what to do with it
+                        }
+                        else
+                        {
+                            this.octants[a] = this.CreateNode(childOctant[a], item); //create a new tree node with the item
+                            this.activeOctants |= (byte)(1 << a);
+                        }
+                        found = true;
+                    }
+                }
+                if (!found)
+                {
+                    this.objects.Add(item);
+                }
+            }
+            else if ((!item.BoundingSphere.Radius.Equals(0f)) && this.region.Contains(item.BoundingSphere) == ContainmentType.Contains)
+            {
+                bool found = false;
+                //we will try to place the object into a child node. If we can't fit it in a child node, then we insert it into the current node object list.
+                for (int a = 0; a < 8; a++)
+                {
+                    //is the object contained within a child quadrant?
+                    if (childOctant[a].Contains(item.BoundingSphere) == ContainmentType.Contains)
+                    {
+                        if (this.octants[a] != null)
+                        {
+                            this.octants[a].Insert(item); //Add the item into that tree and let the child tree figure out what to do with it
+                        }
+                        else
+                        {
+                            this.octants[a] = this.CreateNode(childOctant[a], item); //create a new tree node with the item
+                            this.activeOctants |= (byte)(1 << a);
+                        }
+                        found = true;
+                    }
+                }
+                if (!found)
+                {
+                    this.objects.Add(item);
+                }
+            }
+            else
+            {
+                //either the item lies outside of the enclosed bounding box or it is intersecting it. Either way, we need to rebuild
+                //the entire tree by enlarging the containing bounding box
+                this.BuildTree();
+            }
+        }
+
+        private int NextPowerTwo(int v)
+        {
+            // first round down to one less than a power of 2
+            v |= v >> 1;
+            v |= v >> 2;
+            v |= v >> 4;
+            v |= v >> 8;
+            v |= v >> 16;
+
+            // Debruijn sequence to find most significant bit position
+            int r = (int)this.debruijnPosition[(uint)(v * 0x07C4ACDDU) >> 27];
+
+            // Shift MSB left to find next power 2.
+            return 1 << (r + 1);
+        }
+
+        /// <summary>
+        /// This finds the dimensions of the bounding box necessary to tightly enclose all items in the object list.
+        /// </summary>
+        private void SetEnclosingBox()
+        {
+            Vector3 globalMin = this.region.Min;
+            Vector3 globalMax = this.region.Max;
+
+            //go through all the objects in the list and find the extremes for their bounding areas.
+            foreach (TObject obj in this.objects)
+            {
+                Vector3 localMin = Vector3.zero;
+                Vector3 localMax = Vector3.zero;
+
+                if (obj.BoundingBox.Max != obj.BoundingBox.Min)
+                {
+                    localMin = obj.BoundingBox.Min;
+                    localMax = obj.BoundingBox.Max;
+                }
+
+                if (!obj.BoundingSphere.Radius.Equals(0f))
+                {
+                    localMin = new Vector3(
+                        obj.BoundingSphere.Center.x - obj.BoundingSphere.Radius,
+                        obj.BoundingSphere.Center.x - obj.BoundingSphere.Radius,
+                        obj.BoundingSphere.Center.z - obj.BoundingSphere.Radius);
+
+                    localMax = new Vector3(
+                        obj.BoundingSphere.Center.x + obj.BoundingSphere.Radius,
+                        obj.BoundingSphere.Center.x + obj.BoundingSphere.Radius,
+                        obj.BoundingSphere.Center.z + obj.BoundingSphere.Radius);
+                }
+
+                if (localMin.x < globalMin.x)
+                {
+                    globalMin.x = localMin.x;
+                }
+                if (localMin.y < globalMin.y)
+                {
+                    globalMin.y = localMin.y;
+                }
+                if (localMin.z < globalMin.z)
+                {
+                    globalMin.z = localMin.z;
+                }
+
+                if (localMax.x > globalMax.x)
+                {
+                    globalMax.x = localMax.x;
+                }
+                if (localMax.y > globalMax.y)
+                {
+                    globalMax.y = localMax.y;
+                }
+                if (localMax.z > globalMax.z)
+                {
+                    globalMax.z = localMax.z;
+                }
+            }
+
+            this.region.Min = globalMin;
+            this.region.Max = globalMax;
+        }
+
+        /// <summary>
+        /// This finds the smallest enclosing cube which is a power of 2, for all objects in the list.
+        /// </summary>
+        private void SetEnclosingCube()
+        {
+            this.SetEnclosingBox();
+
+            //find the min offset from (0,0,0) and translate by it for a short while
+            Vector3 offset = this.region.Min - Vector3.zero;
+            this.region.Min += offset;
+            this.region.Max += offset;
+
+            //find the nearest power of two for the max values
+            int highX = (int)Math.Floor(Math.Max(Math.Max(this.region.Max.x, this.region.Max.y), this.region.Max.z));
+
+            //see if we're already at a power of 2
+            for (int bit = 0; bit < 32; bit++)
+            {
+                if (highX == 1 << bit)
+                {
+                    this.region.Max = new Vector3(highX, highX, highX);
+
+                    this.region.Min -= offset;
+                    this.region.Max -= offset;
+                    return;
+                }
+            }
+
+            //gets the most significant bit value, so that we essentially do a Ceiling(X) with the 
+            //ceiling result being to the nearest power of 2 rather than the nearest integer.
+            int x = this.NextPowerTwo(highX);
+
+            this.region.Max = new Vector3(x, x, x);
+
+            this.region.Min -= offset;
+            this.region.Max -= offset;
+        }
+    }
+}

--- a/Assets/Cube Loader/src/Model/OcTree.cs.meta
+++ b/Assets/Cube Loader/src/Model/OcTree.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1b8f455ded6823246bc88808cbc82075
+timeCreated: 1429899091
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/CameraDetection.unity
+++ b/Assets/Scenes/CameraDetection.unity
@@ -323,8 +323,8 @@ MonoBehaviour:
   DetailLevel: 4
   EnableDebugLogs: 0
   PlaceHolderCube: {fileID: 135038, guid: 2f934764d71518942b1b6029f72c985b, type: 2}
-  PyriteServer: 
-  SetName: 
+  PyriteServer: https://pyrite.azurewebsites.net
+  SetName: PerthNew
   UseCameraDetection: 1
   UseEbo: 1
   UseUnlitShader: 1
@@ -354,7 +354,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PyriteServer: 
-  SetName: 
+  SetName: PerthNew
   DetailLevel: 4
   UseUnlitShader: 1
   UseEbo: 1


### PR DESCRIPTION
I ported the Octree class and supporting classes from the server to the client. Some Microsoft.Xna classes used in OcTree do not have a counterpart in Unity, so they were ported over as well.
- OcTree
- Intersection
- IBounds
- Microsoft.Xna - BoundingBox, BoundingFrustrum, BoundingSphere, Matrix - there's also extensions, enums and helper code
